### PR TITLE
Remove ``` _start_with? ``` method from main foobara project

### DIFF
--- a/projects/namespace/src/namespace_helpers.rb
+++ b/projects/namespace/src/namespace_helpers.rb
@@ -268,17 +268,6 @@ module Foobara
             end
           end
         end
-
-        # TODO: move to util
-        def _start_with?(large_array, small_array)
-          return false unless large_array.size > small_array.size
-
-          small_array.each.with_index do |item, index|
-            return false unless large_array[index] == item
-          end
-
-          true
-        end
       end
 
       def foobara_namespace!(scoped_path: nil, ignore_modules: nil)


### PR DESCRIPTION
This is one part of the PR that aims to relocate the ``` _start_with? ``` method from the foobara main project to the util project.

Both these PR's will solve issue #15 