### PR TITLE
Raise for any call to ``` reset_all ``` and ``` reset_alls ``` method

### DIFF
--- a/projects/builtin_types/lib/foobara/builtin_types.rb
+++ b/projects/builtin_types/lib/foobara/builtin_types.rb
@@ -64,6 +64,7 @@ module Foobara
       end
 
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         builtin_types.each do |builtin_type|
           builtin_type.foobara_each do |scoped|
             if scoped.scoped_namespace == builtin_type

--- a/projects/command/lib/foobara/command.rb
+++ b/projects/command/lib/foobara/command.rb
@@ -9,6 +9,7 @@ module Foobara
       end
 
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         to_delete = []
 
         all.each do |command_class|

--- a/projects/command/src/command_pattern_implementation/concerns/reflection.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/reflection.rb
@@ -16,6 +16,7 @@ module Foobara
           end
 
           def reset_all
+            Foobara.raise_if_production!("reset_all")
             remove_instance_variable("@all") if instance_variable_defined?("@all")
           end
 

--- a/projects/command_connectors/lib/foobara/command_connectors.rb
+++ b/projects/command_connectors/lib/foobara/command_connectors.rb
@@ -24,6 +24,7 @@ module Foobara
       end
 
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         remove_instance_variable("@desugarizer") if defined?(@desugarizer)
         remove_instance_variable("@desugarizers") if defined?(@desugarizers)
       end

--- a/projects/detached_entity/lib/foobara/detached_entity.rb
+++ b/projects/detached_entity/lib/foobara/detached_entity.rb
@@ -16,6 +16,7 @@ module Foobara
       end
 
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         install!
       end
     end

--- a/projects/entity/lib/foobara/entity.rb
+++ b/projects/entity/lib/foobara/entity.rb
@@ -21,6 +21,7 @@ module Foobara
       end
 
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         Entity::Concerns::Callbacks.reset_all
 
         install!

--- a/projects/entity/src/concerns/callbacks.rb
+++ b/projects/entity/src/concerns/callbacks.rb
@@ -6,6 +6,7 @@ module Foobara
 
         class << self
           def reset_all
+            Foobara.raise_if_production!("reset_all")
             Entity.instance_variable_set("@class_callback_registry", nil)
           end
         end

--- a/projects/foobara/src/project.rb
+++ b/projects/foobara/src/project.rb
@@ -34,6 +34,7 @@ module Foobara
     end
 
     def reset_all
+      Foobara.raise_if_production!("reset_all")
       if self.module.respond_to?(:reset_all)
         self.module.reset_all
       end

--- a/projects/model/lib/foobara/model.rb
+++ b/projects/model/lib/foobara/model.rb
@@ -28,6 +28,7 @@ module Foobara
       end
 
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         install!
       end
     end

--- a/projects/persistence/lib/foobara/persistence.rb
+++ b/projects/persistence/lib/foobara/persistence.rb
@@ -2,6 +2,7 @@ module Foobara
   module Persistence
     class << self
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         @tables_for_entity_class_name = @bases = @default_crud_driver = @default_base = nil
         EntityBase::Transaction::Concerns::EntityCallbackHandling.reset_all
         EntityBase::Transaction.reset_all

--- a/projects/persistence/src/entity_base/transaction/concerns/entity_callback_handling.rb
+++ b/projects/persistence/src/entity_base/transaction/concerns/entity_callback_handling.rb
@@ -10,6 +10,7 @@ module Foobara
           module EntityCallbackHandling
             class << self
               def reset_all
+                Foobara.raise_if_production!("reset_all")
                 install!
               end
 

--- a/projects/persistence/src/entity_base/transaction/concerns/transaction_tracking.rb
+++ b/projects/persistence/src/entity_base/transaction/concerns/transaction_tracking.rb
@@ -21,6 +21,7 @@ module Foobara
               end
 
               def reset_all
+                Foobara.raise_if_production!("reset_all")
                 @open_transactions = nil
               end
 

--- a/projects/type_declarations/lib/foobara/type_declarations.rb
+++ b/projects/type_declarations/lib/foobara/type_declarations.rb
@@ -2,6 +2,7 @@ module Foobara
   module TypeDeclarations
     class << self
       def reset_all
+        Foobara.raise_if_production!("reset_all")
         # TODO: this doesn't really belong here. I think we need to maybe call reset in reverse order?
         Foobara::Domain::DomainModuleExtension.all.each do |domain|
           var = "@foobara_type_builder"


### PR DESCRIPTION
This PR adds the ability to raise whenever there is a method call to ``` reset_all ``` and ``` reset_alls``` in the production environment. 