### PR TITLE
Refactor to remove use of ```foobara_delegate```

### DIFF
--- a/projects/builtin_types/src/builtin_types.rb
+++ b/projects/builtin_types/src/builtin_types.rb
@@ -5,7 +5,9 @@ module Foobara
 
   module BuiltinTypes
     class << self
-      foobara_delegate :global_type_declaration_handler_registry, to: TypeDeclarations
+      def global_type_declaration_handler_registry(...)
+        TypeDeclarations.global_type_declaration_handler_registry(...)
+      end
 
       # TODO: break this up
       # TODO: much of this behavior is helpful to non-builtin types as well.

--- a/projects/callback/src/block.rb
+++ b/projects/callback/src/block.rb
@@ -26,7 +26,9 @@ module Foobara
         validate_original_block!
       end
 
-      foobara_delegate :type, to: :class
+      def type(...)
+        self.class.type(...)
+      end
 
       def call(...)
         to_proc.call(...)

--- a/projects/callback/src/registry/chained_conditioned.rb
+++ b/projects/callback/src/registry/chained_conditioned.rb
@@ -6,7 +6,13 @@ module Foobara
       class ChainedConditioned < Conditioned
         attr_accessor :other_conditions_registry
 
-        foobara_delegate :possible_conditions, :possible_condition_keys, to: :other_conditions_registry
+        def possible_conditions(...)
+          other_conditions_registry.possible_conditions(...)
+        end
+
+        def possible_condition_keys(...)
+          other_conditions_registry.possible_condition_keys(...)
+        end
 
         def initialize(other_conditions_registry)
           self.other_conditions_registry = other_conditions_registry

--- a/projects/callback/src/registry/chained_multiple_action.rb
+++ b/projects/callback/src/registry/chained_multiple_action.rb
@@ -8,7 +8,13 @@ module Foobara
 
         class InvalidConditions < StandardError; end
 
-        foobara_delegate :possible_actions, :allowed_types, to: :other_multiple_actions_registry
+        def possible_actions(...)
+          other_multiple_actions_registry.possible_actions(...)
+        end
+
+        def allowed_types(...)
+          other_multiple_actions_registry.allowed_types(...)
+        end
 
         def initialize(other_multiple_actions_registry)
           self.other_multiple_actions_registry = other_multiple_actions_registry

--- a/projects/callback/src/registry/joined_conditioned.rb
+++ b/projects/callback/src/registry/joined_conditioned.rb
@@ -6,7 +6,13 @@ module Foobara
       class JoinedConditioned < Conditioned
         attr_accessor :first, :second
 
-        foobara_delegate :possible_conditions, :possible_condition_keys, to: :first
+        def possible_conditions(...)
+          first.possible_conditions(...)
+        end
+
+        def possible_condition_keys(...)
+          first.possible_condition_keys(...)
+        end
 
         def initialize(first, second)
           self.first = first

--- a/projects/callback/src/set.rb
+++ b/projects/callback/src/set.rb
@@ -11,7 +11,9 @@ module Foobara
         end
       end
 
-      foobara_delegate :size, to: :callbacks
+      def size(...)
+        callbacks.size(...)
+      end
 
       def union(set)
         unioned = Set.new(callbacks)

--- a/projects/command/src/command_pattern_implementation/concerns/errors.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/errors.rb
@@ -53,7 +53,9 @@ module Foobara
           super
         end
 
-        foobara_delegate :has_errors?, to: :error_collection
+        def has_errors?(...)
+          error_collection.has_errors?(...)
+        end
 
         private
 

--- a/projects/command/src/command_pattern_implementation/concerns/inputs_type.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/inputs_type.rb
@@ -61,7 +61,13 @@ module Foobara
           end
         end
 
-        foobara_delegate :inputs_type, :raw_inputs_type_declaration, to: :class
+        def inputs_type(...)
+          self.class.inputs_type(...)
+        end
+
+        def raw_inputs_type_declaration(...)
+          self.class.raw_inputs_type_declaration(...)
+        end
       end
     end
   end

--- a/projects/command/src/command_pattern_implementation/concerns/namespace.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/namespace.rb
@@ -42,7 +42,9 @@ module Foobara
           end
         end
 
-        foobara_delegate :type_for_declaration, to: :class
+        def type_for_declaration(...)
+          self.class.type_for_declaration(...)
+        end
       end
     end
   end

--- a/projects/command/src/command_pattern_implementation/concerns/reflection.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/reflection.rb
@@ -180,7 +180,9 @@ module Foobara
           end
         end
 
-        foobara_delegate :type_for_declaration, to: :class
+        def type_for_declaration(...)
+          self.class.type_for_declaration(...)
+        end
       end
     end
   end

--- a/projects/command/src/command_pattern_implementation/concerns/result_type.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/result_type.rb
@@ -22,7 +22,13 @@ module Foobara
           end
         end
 
-        foobara_delegate :result_type, :raw_result_type_declaration, to: :class
+        def result_type(...)
+          self.class.result_type(...)
+        end
+
+        def raw_result_type_declaration(...)
+          self.class.raw_result_type_declaration(...)
+        end
       end
     end
   end

--- a/projects/command/src/command_pattern_implementation/concerns/subcommands.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/subcommands.rb
@@ -10,7 +10,9 @@ module Foobara
 
         attr_accessor :is_subcommand
 
-        foobara_delegate :verify_depends_on!, to: :class
+        def verify_depends_on!(...)
+          self.class.verify_depends_on!(...)
+        end
 
         def subcommand?
           is_subcommand

--- a/projects/command_connectors/src/command_connector.rb
+++ b/projects/command_connectors/src/command_connector.rb
@@ -145,19 +145,53 @@ module Foobara
       self.class.find_builtin_command_class(command_class_name)
     end
 
-    foobara_delegate :add_default_inputs_transformer,
-                     :add_default_result_transformer,
-                     :add_default_errors_transformer,
-                     :add_default_pre_commit_transformer,
-                     :add_default_serializer,
-                     :add_default_response_mutator,
-                     :allowed_rule,
-                     :allowed_rules,
-                     :transform_command_class,
-                     :transformed_command_from_name,
-                     :each_transformed_command_class,
-                     :all_transformed_command_classes,
-                     to: :command_registry
+    def add_default_inputs_transformer(...)
+      command_registry.add_default_inputs_transformer(...)
+    end
+
+    def add_default_result_transformer(...)
+      command_registry.add_default_result_transformer(...)
+    end
+
+    def add_default_errors_transformer(...)
+      command_registry.add_default_errors_transformer(...)
+    end
+
+    def add_default_pre_commit_transformer(...)
+      command_registry.add_default_pre_commit_transformer(...)
+    end
+
+    def add_default_serializer(...)
+      command_registry.add_default_serializer(...)
+    end
+
+    def add_default_response_mutator(...)
+      command_registry.add_default_response_mutator(...)
+    end
+
+    def allowed_rule(...)
+      command_registry.allowed_rule(...)
+    end
+
+    def allowed_rules(...)
+      command_registry.allowed_rules(...)
+    end
+
+    def transform_command_class(...)
+      command_registry.transform_command_class(...)
+    end
+
+    def transformed_command_from_name(...)
+      command_registry.transformed_command_from_name(...)
+    end
+
+    def each_transformed_command_class(...)
+      command_registry.each_transformed_command_class(...)
+    end
+
+    def all_transformed_command_classes(...)
+      command_registry.all_transformed_command_classes(...)
+    end
 
     def lookup_command(name)
       command_registry.foobara_lookup_command(name)

--- a/projects/command_connectors/src/transformed_command.rb
+++ b/projects/command_connectors/src/transformed_command.rb
@@ -61,10 +61,17 @@ module Foobara
         end
       end
 
-      foobara_delegate :description,
-                       :domain,
-                       :organization,
-                       to: :command_class
+      def description(...)
+        command_class.description(...)
+      end
+
+      def domain(...)
+        command_class.domain(...)
+      end
+
+      def organization(...)
+        command_class.organization(...)
+      end
 
       def result_transformers
         return @result_transformers if @considered_sensitive_value_remover
@@ -559,19 +566,53 @@ module Foobara
       construct_command
     end
 
-    foobara_delegate :description, to: :command_class
-    foobara_delegate :full_command_name,
-                     :command_name,
-                     :command_class,
-                     :capture_unknown_error,
-                     :inputs_transformers,
-                     :result_transformers,
-                     :errors_transformers,
-                     :pre_commit_transformers,
-                     :serializers,
-                     :allowed_rule,
-                     :authenticator,
-                     to: :class
+    def description(...)
+      command_class.description(...)
+    end
+
+    def full_command_name(...)
+      self.class.full_command_name(...)
+    end
+
+    def command_name(...)
+      self.class.command_name(...)
+    end
+
+    def command_class(...)
+      self.class.command_class(...)
+    end
+
+    def capture_unknown_error(...)
+      self.class.capture_unknown_error(...)
+    end
+
+    def inputs_transformers(...)
+      self.class.inputs_transformers(...)
+    end
+
+    def result_transformers(...)
+      self.class.result_transformers(...)
+    end
+
+    def errors_transformers(...)
+      self.class.errors_transformers(...)
+    end
+
+    def pre_commit_transformers(...)
+      self.class.pre_commit_transformers(...)
+    end
+
+    def serializers(...)
+      self.class.serializers(...)
+    end
+
+    def allowed_rule(...)
+      self.class.allowed_rule(...)
+    end
+
+    def authenticator(...)
+      self.class.authenticator(...)
+    end
 
     def run
       apply_allowed_rule

--- a/projects/common/src/outcome.rb
+++ b/projects/common/src/outcome.rb
@@ -55,11 +55,21 @@ module Foobara
       end
     end
 
-    foobara_delegate :has_errors?,
-                     :has_error?,
-                     :add_error,
-                     :add_errors,
-                     to: :error_collection
+    def has_errors?(...)
+      error_collection.has_errors?(...)
+    end
+
+    def has_error?(...)
+      error_collection.has_error?(...)
+    end
+
+    def add_error(...)
+      error_collection.add_error(...)
+    end
+
+    def add_errors(...)
+      error_collection.add_errors(...)
+    end
 
     def errors
       error_collection

--- a/projects/detached_entity/src/concerns/primary_key.rb
+++ b/projects/detached_entity/src/concerns/primary_key.rb
@@ -4,7 +4,9 @@ module Foobara
       module PrimaryKey
         include Concern
 
-        foobara_delegate :primary_key_attribute, to: :class
+        def primary_key_attribute(...)
+          self.class.primary_key_attribute(...)
+        end
 
         module ClassMethods
           def primary_key(attribute_name)

--- a/projects/detached_entity/src/concerns/types.rb
+++ b/projects/detached_entity/src/concerns/types.rb
@@ -4,7 +4,13 @@ module Foobara
       module Types
         include Concern
 
-        foobara_delegate :full_entity_name, :entity_name, to: :class
+        def full_entity_name(...)
+          self.class.full_entity_name(...)
+        end
+
+        def entity_name(...)
+          self.class.entity_name(...)
+        end
 
         module ClassMethods
           def entity_type

--- a/projects/entity/src/concerns/callbacks.rb
+++ b/projects/entity/src/concerns/callbacks.rb
@@ -35,7 +35,9 @@ module Foobara
           end
         end
 
-        foobara_delegate :register_callback, to: :callback_registry
+        def register_callback(...)
+          callback_registry.register_callback(...)
+        end
 
         module ClassMethods
           def class_callback_registry
@@ -68,7 +70,13 @@ module Foobara
             end
           end
 
-          foobara_delegate :register_callback, :possible_actions, to: :class_callback_registry
+          def register_callback(...)
+            class_callback_registry.register_callback(...)
+          end
+
+          def possible_actions(...)
+            class_callback_registry.possible_actions(...)
+          end
         end
 
         on_include do

--- a/projects/entity/src/not_found_error.rb
+++ b/projects/entity/src/not_found_error.rb
@@ -53,7 +53,13 @@ module Foobara
         data_path :string # TODO: we don't have a way to specify an exact value for a type
       end
 
-      foobara_delegate :primary_key_attribute, :full_entity_name, to: :entity_class
+      def primary_key_attribute(...)
+        entity_class.primary_key_attribute(...)
+      end
+
+      def full_entity_name(...)
+        entity_class.full_entity_name(...)
+      end
 
       def criteria
         context[:criteria]

--- a/projects/model/src/concerns/types.rb
+++ b/projects/model/src/concerns/types.rb
@@ -4,7 +4,9 @@ module Foobara
       module Types
         include Concern
 
-        foobara_delegate :attributes_type, to: :class
+        def attributes_type(...)
+          self.class.attributes_type(...)
+        end
 
         module ClassMethods
           attr_reader :model_type

--- a/projects/model/src/model.rb
+++ b/projects/model/src/model.rb
@@ -229,7 +229,17 @@ module Foobara
       validate! if validate # TODO: test this code path
     end
 
-    foobara_delegate :model_name, :valid_attribute_name?, :validate_attribute_name!, to: :class
+    def model_name(...)
+      self.class.model_name(...)
+    end
+
+    def valid_attribute_name?(...)
+      self.class.valid_attribute_name?(...)
+    end
+
+    def validate_attribute_name!(...)
+      self.class.validate_attribute_name!(...)
+    end
 
     def attributes
       @attributes ||= {}

--- a/projects/persistence/src/entity_base/transaction.rb
+++ b/projects/persistence/src/entity_base/transaction.rb
@@ -14,7 +14,9 @@ module Foobara
           self.tables = {}
         end
 
-        foobara_delegate :entity_attributes_crud_driver, to: :entity_base
+        def entity_attributes_crud_driver(...)
+          entity_base.entity_attributes_crud_driver(...)
+        end
 
         def create(entity_class, attributes = {})
           Persistence.to_base(entity_class).transaction(existing_transaction: self) do

--- a/projects/persistence/src/entity_base/transaction/concerns/state_transitions.rb
+++ b/projects/persistence/src/entity_base/transaction/concerns/state_transitions.rb
@@ -7,7 +7,13 @@ module Foobara
 
         module Concerns
           module StateTransitions
-            foobara_delegate :close!, :currently_open?, to: :state_machine
+            def close!(...)
+              state_machine.close!(...)
+            end
+
+            def currently_open?(...)
+              state_machine.currently_open?
+            end
 
             def open!
               state_machine.open! do

--- a/projects/state_machine/src/callbacks.rb
+++ b/projects/state_machine/src/callbacks.rb
@@ -9,14 +9,33 @@ module Foobara
         self.callback_registry = Callback::Registry::ChainedConditioned.new(self.class.class_callback_registry)
       end
 
-      foobara_delegate :callbacks_for,
-                       :has_callbacks?,
-                       :has_before_callbacks?,
-                       :has_after_callbacks?,
-                       :has_around_callbacks?,
-                       :has_error_callbacks?,
-                       :has_failure_callbacks?,
-                       to: :callback_registry
+      def callbacks_for(...)
+        callback_registry.callbacks_for(...)
+      end
+
+      def has_callbacks?(...)
+        callback_registry.has_callbacks?(...)
+      end
+
+      def has_before_callbacks?(...)
+        callback_registry.has_before_callbacks?(...)
+      end
+
+      def has_after_callbacks?(...)
+        callback_registry.has_after_callbacks?(...)
+      end
+
+      def has_around_callbacks?(...)
+        callback_registry.has_around_callbacks?(...)
+      end
+
+      def has_error_callbacks?(...)
+        callback_registry.has_error_callbacks?(...)
+      end
+
+      def has_failure_callbacks?(...)
+        callback_registry.has_failure_callbacks?(...)
+      end
 
       def register_transition_callback(type, **, &)
         callback_registry.register_callback(type, **, &)

--- a/projects/type_declarations/src/error_extension.rb
+++ b/projects/type_declarations/src/error_extension.rb
@@ -67,7 +67,13 @@ module Foobara
         end
       end
 
-      foobara_delegate :context_type, :context_type_declaration, to: :class
+      def context_type(...)
+        self.class.context_type(...)
+      end
+
+      def context_type_declaration(...)
+        self.class.context_type_declaration(...)
+      end
     end
   end
 end

--- a/projects/type_declarations/src/type_declaration_handler.rb
+++ b/projects/type_declarations/src/type_declaration_handler.rb
@@ -60,11 +60,21 @@ module Foobara
         super(*Util.args_and_opts_to_args(args, opts))
       end
 
-      foobara_delegate :starting_desugarizers,
-                       :starting_desugarizers_with_inherited,
-                       :starting_desugarizers_without_inherited,
-                       :starting_type_declaration_validators,
-                       to: :class
+      def starting_desugarizers(...)
+        self.class.starting_desugarizers(...)
+      end
+
+      def starting_desugarizers_with_inherited(...)
+        self.class.starting_desugarizers_with_inherited(...)
+      end
+
+      def starting_desugarizers_without_inherited(...)
+        self.class.starting_desugarizers_without_inherited(...)
+      end
+
+      def starting_type_declaration_validators(...)
+        self.class.starting_type_declaration_validators(...)
+      end
 
       def to_type_transformer
         self.class::ToTypeTransformer.instance

--- a/projects/type_declarations/src/with_registries.rb
+++ b/projects/type_declarations/src/with_registries.rb
@@ -29,14 +29,33 @@ module Foobara
         end
       end
 
-      foobara_delegate :type_for_declaration,
-                       :type_declaration_handler_for,
-                       :lookup_type,
-                       :lookup_type!,
-                       :lookup_absolute_type!,
-                       :type_registered?,
-                       :handler_for_class,
-                       to: :class
+      def type_for_declaration(...)
+        self.class.type_for_declaration(...)
+      end
+
+      def type_declaration_handler_for(...)
+        self.class.type_declaration_handler_for(...)
+      end
+
+      def lookup_type(...)
+        self.class.lookup_type(...)
+      end
+
+      def lookup_type!(...)
+        self.class.lookup_type!(...)
+      end
+
+      def lookup_absolute_type!(...)
+        self.class.lookup_absolute_type!(...)
+      end
+
+      def type_registered?(...)
+        self.class.type_registered?(...)
+      end
+
+      def handler_for_class(...)
+        self.class.handler_for_class(...)
+      end
     end
   end
 end

--- a/projects/types/src/type.rb
+++ b/projects/types/src/type.rb
@@ -321,7 +321,9 @@ module Foobara
         value_caster.can_cast?(value)
       end
 
-      foobara_delegate :needs_cast?, to: :value_caster
+      def needs_cast?(...)
+        value_caster.needs_cast?(...)
+      end
 
       def cast(value)
         value_caster.process_value(value)

--- a/projects/value/src/processor.rb
+++ b/projects/value/src/processor.rb
@@ -177,12 +177,25 @@ module Foobara
         self.class.processor_name
       end
 
-      foobara_delegate :error_class,
-                       :error_classes,
-                       :symbol,
-                       :requires_declaration_data?,
-                       :requires_parent_declaration_data?,
-                       to: :class
+      def error_class(...)
+        self.class.error_class(...)
+      end
+
+      def error_classes(...)
+        self.class.error_classes(...)
+      end
+
+      def symbol(...)
+        self.class.symbol(...)
+      end
+
+      def requires_declaration_data?(...)
+        self.class.requires_declaration_data?(...)
+      end
+
+      def requires_parent_declaration_data?(...)
+        self.class.requires_parent_declaration_data?(...)
+      end
 
       # Whoa, forgot this existed. Shouldn't we use this more?
       def runner(value)

--- a/spec/builtin_types/custom_type_spec.rb
+++ b/spec/builtin_types/custom_type_spec.rb
@@ -58,7 +58,9 @@ RSpec.describe "custom types" do
           ]
         end
 
-        foobara_delegate :sugar_for_complex?, to: :class
+        def sugar_for_complex?(...)
+          self.class.sugar_for_complex?(...)
+        end
       end
 
       stub_class "ComplexTypeDeclarationHandler::SomeDesugarizer", Foobara::TypeDeclarations::Desugarizer do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ end
 
 require "foobara/all"
 require "foobara/command_connectors"
+require_relative "../projects/value/lib/foobara/value"
 
 RSpec.configure do |config|
   # Need to do :all instead of :each because for specs that use .around,


### PR DESCRIPTION
This PR is meant to finalize the refactor to remove ```foobara_delegate``` and eventually remove the ```delegate``` project from the code base