### PR TITLE
update domain name (fix: #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2100,11 +2100,11 @@ TODO: give some code examples
 # Additional learning materials/Documentation
 
 * Overview and code demo videos:
-  * https://foobara.com/videos
+  * https://foobara.org/videos
   * https://www.youtube.com/@FoobaraFlix
 * YARD Docs
   * All docs combined: https://docs.foobara.com/all/
-  * Per-repository docs: https://foobara.com/docs
+  * Per-repository docs: https://foobara.org/docs
 
 # Help
 

--- a/foobara.gemspec
+++ b/foobara.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A command-centric and discoverable software framework with a focus on domain concepts " \
                  "and abstracting away integration code"
   spec.description = spec.summary
-  spec.homepage = "https://foobara.com"
+  spec.homepage = "https://foobara.org"
   spec.license = "MPL-2.0"
   spec.required_ruby_version = Foobara::Version::MINIMUM_RUBY_VERSION
 


### PR DESCRIPTION
This PR addresses the issue #24 and updates the domain name from "foobara.com" to "foobara.org" in appropriate places.