### PR TITLE
Replace `require_project_file` with `require_relative`

### DIFF
--- a/projects/command_connectors/src/serializers/errors_serializer.rb
+++ b/projects/command_connectors/src/serializers/errors_serializer.rb
@@ -1,5 +1,5 @@
 module Foobara
-  require_project_file("command_connectors", "serializer")
+  require_relative "../serializer"
 
   module CommandConnectors
     module Serializers

--- a/projects/command_connectors/src/serializers/success_serializer.rb
+++ b/projects/command_connectors/src/serializers/success_serializer.rb
@@ -1,5 +1,5 @@
 module Foobara
-  require_project_file("command_connectors", "serializer")
+  require_relative "../serializer"
 
   module CommandConnectors
     module Serializers

--- a/projects/foobara/src/foobara.rb
+++ b/projects/foobara/src/foobara.rb
@@ -5,7 +5,10 @@ module Foobara
 
   class << self
     def require_project_file(project, path)
+      # :nocov:
+      warn "DEPRECATION WARNING: require_project_file is deprecated. Use require_relative instead."
       require_relative("../../#{project}/src/#{path}")
+      # :nocov:
     end
 
     attr_accessor :is_installed

--- a/projects/state_machine/src/state_machine.rb
+++ b/projects/state_machine/src/state_machine.rb
@@ -1,8 +1,8 @@
 module Foobara
-  require_project_file("state_machine", "sugar")
-  require_project_file("state_machine", "callbacks")
-  require_project_file("state_machine", "validations")
-  require_project_file("state_machine", "transitions")
+  require_relative "sugar"
+  require_relative "callbacks"
+  require_relative "validations"
+  require_relative "transitions"
 
   # TODO: allow quick creation of a statemachine either through better options to #initialize or a
   # .for method.

--- a/projects/type_declarations/src/type_declarations.rb
+++ b/projects/type_declarations/src/type_declarations.rb
@@ -1,8 +1,8 @@
 require "inheritable_thread_vars"
 
 module Foobara
-  require_project_file("type_declarations", "type_builder")
-  require_project_file("type_declarations", "error_extension")
+  require_relative "type_builder"
+  require_relative "error_extension"
 
   module TypeDeclarations
     module Mode


### PR DESCRIPTION
Closes #34

**Changes in this PR**
- Replaced all `require_project_file` calls with `require_relative`
- Added deprecation warning for `require_project_file` method