### PR TITLE
wrapping the new module with DetachedEntity

### DIFF
--- a/projects/detached_entity/lib/foobara/detached_entity.rb
+++ b/projects/detached_entity/lib/foobara/detached_entity.rb
@@ -14,7 +14,7 @@ module Foobara
         model = Namespace.global.foobara_lookup_type!(:model)
         BuiltinTypes.build_and_register!(:detached_entity, model, nil)
 
-        TypeDeclarations::RemoveSensitiveValuesTransformer.include(DetachedEntity::RemoveSensitiveValuesTransformerExtensions)
+        TypeDeclarations::RemoveSensitiveValuesTransformer.include(RemoveSensitiveValuesTransformerExtensions)
       end
 
       def reset_all


### PR DESCRIPTION
This PR fixes some mistakes made in #41

Changes made:
Wrap the new module `RemoveSensitiveValuesTransformerExtensions` under the class `DetachedEntity`
Update the install! method for `DetachedEntity` project to accomodate the namespacing changes
