### PR TITLE
Renamed BaseManifest#path to BaseManifest#manifest_path

### DIFF
--- a/projects/manifest/spec/manifest_spec.rb
+++ b/projects/manifest/spec/manifest_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Foobara::Manifest do
     expect(detached_entity.primary_key_name).to eq("id")
     expect(detached_entity).to_not have_associations
     expect(detached_entity).to be_detached_entity
-    Foobara::Manifest::TypeDeclaration.new(raw_manifest, [*detached_entity.path, :declaration_data])
+    Foobara::Manifest::TypeDeclaration.new(raw_manifest, [*detached_entity.manifest_path, :declaration_data])
     some_other_domain = manifest.domain_by_name("SomeOtherDomain")
     #     expect(declaration.to_type).to be_detached_entity
     expect(some_other_domain.detached_entities).to include(detached_entity)
@@ -215,7 +215,7 @@ RSpec.describe Foobara::Manifest do
     expect(attribute).to_not be_required
     expect(attribute.default).to eq([])
 
-    new_attributes = Foobara::Manifest::TypeDeclaration.new(attributes.root_manifest, attributes.path)
+    new_attributes = Foobara::Manifest::TypeDeclaration.new(attributes.root_manifest, attributes.manifest_path)
     expect(new_attributes).to be_a(Foobara::Manifest::Attributes)
     expect(new_attributes).to be_attributes
     expect(new_attributes).to eql(attributes)
@@ -272,7 +272,7 @@ RSpec.describe Foobara::Manifest do
     expect(command.command_manifest).to be_a(Hash)
     expect(command.inputs_type).to be_a(Foobara::Manifest::Attributes)
     expect(command.inputs_type.required).to be_nil
-    command = Foobara::Manifest::Command.new(raw_stringified_manifest, command.path)
+    command = Foobara::Manifest::Command.new(raw_stringified_manifest, command.manifest_path)
     expect(command.inputs_type.required).to be_nil
     some_other_user_declaration = command.inputs_type.attribute_declarations[:some_other_user]
     expect(command.domain.find_type(some_other_user_declaration)).to be_a(Foobara::Manifest::Entity)

--- a/projects/manifest/src/array.rb
+++ b/projects/manifest/src/array.rb
@@ -6,7 +6,7 @@ module Foobara
       alias array_manifest relevant_manifest
 
       def element_type
-        @element_type ||= TypeDeclaration.new(root_manifest, [*path, :element_type_declaration])
+        @element_type ||= TypeDeclaration.new(root_manifest, [*manifest_path, :element_type_declaration])
       end
     end
   end

--- a/projects/manifest/src/attributes.rb
+++ b/projects/manifest/src/attributes.rb
@@ -27,7 +27,7 @@ module Foobara
         element_type_declarations.keys.to_h do |attribute_name|
           [
             attribute_name.to_sym,
-            TypeDeclaration.new(root_manifest, [*path, :element_type_declarations, attribute_name])
+            TypeDeclaration.new(root_manifest, [*manifest_path, :element_type_declarations, attribute_name])
           ]
         end
       end

--- a/projects/manifest/src/base_manifest.rb
+++ b/projects/manifest/src/base_manifest.rb
@@ -5,7 +5,7 @@ module Foobara
     class BaseManifest
       include TruncatedInspect
 
-      attr_accessor :root_manifest, :path
+      attr_accessor :root_manifest, :manifest_path
 
       class << self
         attr_accessor :category_symbol
@@ -50,15 +50,22 @@ module Foobara
         end
       end
 
-      def initialize(root_manifest, path)
+      def initialize(root_manifest, manifest_path)
         self.root_manifest = root_manifest
-        self.path = path
+        self.manifest_path = manifest_path
 
         if relevant_manifest.nil?
           # :nocov:
-          raise InvalidPath, "invalid path #{path}"
+          raise InvalidPath, "invalid path #{manifest_path}"
           # :nocov:
         end
+      end
+
+      def path
+        # :nocov:
+        warn "[DEPRECATION] `path` is deprecated. Please use `manifest_path` instead."
+        manifest_path
+        # :nocov:
       end
 
       def domain
@@ -94,7 +101,7 @@ module Foobara
       end
 
       def relevant_manifest
-        @relevant_manifest ||= Foobara::DataPath.values_at(path, root_manifest).first
+        @relevant_manifest ||= Foobara::DataPath.values_at(manifest_path, root_manifest).first
       end
 
       def find_type(type_declaration)
@@ -155,7 +162,7 @@ module Foobara
       end
 
       def symbol_path
-        @symbol_path ||= path.map(&:to_sym)
+        @symbol_path ||= manifest_path.map(&:to_sym)
       end
 
       def hash

--- a/projects/manifest/src/command.rb
+++ b/projects/manifest/src/command.rb
@@ -22,18 +22,18 @@ module Foobara
       end
 
       def inputs_type
-        Attributes.new(root_manifest, [*path, :inputs_type])
+        Attributes.new(root_manifest, [*manifest_path, :inputs_type])
       end
 
       def result_type
-        TypeDeclaration.new(root_manifest, [*path, :result_type])
+        TypeDeclaration.new(root_manifest, [*manifest_path, :result_type])
       rescue Foobara::Manifest::InvalidPath
         nil
       end
 
       def possible_errors
         (super || {}).keys.to_h do |key|
-          [key, PossibleError.new(root_manifest, [*path, :possible_errors, key])]
+          [key, PossibleError.new(root_manifest, [*manifest_path, :possible_errors, key])]
         end
       end
 

--- a/projects/manifest/src/detached_entity.rb
+++ b/projects/manifest/src/detached_entity.rb
@@ -15,7 +15,7 @@ module Foobara
       end
 
       def primary_key_type
-        @primary_key_type ||= TypeDeclaration.new(root_manifest, [*path, :primary_key_type])
+        @primary_key_type ||= TypeDeclaration.new(root_manifest, [*manifest_path, :primary_key_type])
       end
 
       def attribute_names

--- a/projects/manifest/src/model.rb
+++ b/projects/manifest/src/model.rb
@@ -8,7 +8,7 @@ module Foobara
       alias model_manifest relevant_manifest
 
       def attributes_type
-        Attributes.new(root_manifest, [*path, :declaration_data, :attributes_declaration])
+        Attributes.new(root_manifest, [*manifest_path, :declaration_data, :attributes_declaration])
       end
 
       def attribute_names

--- a/projects/manifest/src/type.rb
+++ b/projects/manifest/src/type.rb
@@ -10,11 +10,11 @@ module Foobara
 
           if self == Type
             if type.entity?
-              type = Entity.new(type.root_manifest, type.path)
+              type = Entity.new(type.root_manifest, type.manifest_path)
             elsif type.detached_entity?
-              type = DetachedEntity.new(type.root_manifest, type.path)
+              type = DetachedEntity.new(type.root_manifest, type.manifest_path)
             elsif type.model?
-              type = Model.new(type.root_manifest, type.path)
+              type = Model.new(type.root_manifest, type.manifest_path)
             end
           end
 
@@ -105,7 +105,7 @@ module Foobara
       end
 
       def to_type_declaration_from_declaration_data
-        TypeDeclaration.new(root_manifest, [*path, :declaration_data])
+        TypeDeclaration.new(root_manifest, [*manifest_path, :declaration_data])
       end
     end
   end

--- a/projects/manifest/src/type_declaration.rb
+++ b/projects/manifest/src/type_declaration.rb
@@ -12,9 +12,9 @@ module Foobara
           if self == TypeDeclaration
             case type_declaration.type.to_sym
             when :attributes
-              Attributes.new(type_declaration.root_manifest, type_declaration.path)
+              Attributes.new(type_declaration.root_manifest, type_declaration.manifest_path)
             when :array
-              Array.new(type_declaration.root_manifest, type_declaration.path)
+              Array.new(type_declaration.root_manifest, type_declaration.manifest_path)
             else
               type_declaration
             end
@@ -37,7 +37,7 @@ module Foobara
       def attribute?
         return @is_attribute if defined?(@is_attribute)
 
-        parent_path_atom = path[2..][-2]
+        parent_path_atom = manifest_path[2..][-2]
         @is_attribute = [:element_type_declarations, "element_type_declarations"].include?(parent_path_atom)
       end
       # rubocop:enable Naming/MemoizedInstanceVariableName
@@ -47,7 +47,7 @@ module Foobara
 
         raise "Not an attribute" unless attribute?
 
-        @parent_attributes = Attributes.new(root_manifest, path[0..-3])
+        @parent_attributes = Attributes.new(root_manifest, manifest_path[0..-3])
       end
 
       def attribute_name
@@ -55,7 +55,7 @@ module Foobara
 
         raise "Not an attribute" unless attribute?
 
-        @attribute_name = path[-1]
+        @attribute_name = manifest_path[-1]
       end
 
       def required?


### PR DESCRIPTION
printing Deprecation wanring on use of BaseManifest#path as well. 

fixes #52 