### PR TITLE
feat: infer caller name in raise_if_production!; deprecate method_name

### DIFF
--- a/projects/command_connectors/lib/foobara/command_connectors.rb
+++ b/projects/command_connectors/lib/foobara/command_connectors.rb
@@ -25,7 +25,7 @@ module Foobara
       end
 
       def reset_all
-        Foobara.raise_if_production!("reset_all")
+        Foobara.raise_if_production!
         remove_instance_variable("@desugarizer") if defined?(@desugarizer)
         remove_instance_variable("@desugarizers") if defined?(@desugarizers)
       end

--- a/projects/entities/projects/detached_entity/lib/foobara/detached_entity.rb
+++ b/projects/entities/projects/detached_entity/lib/foobara/detached_entity.rb
@@ -20,7 +20,7 @@ module Foobara
       end
 
       def reset_all
-        Foobara.raise_if_production!("reset_all")
+        Foobara.raise_if_production!
         install!
       end
     end

--- a/projects/entities/projects/entity/lib/foobara/entity.rb
+++ b/projects/entities/projects/entity/lib/foobara/entity.rb
@@ -23,7 +23,7 @@ module Foobara
       end
 
       def reset_all
-        Foobara.raise_if_production!("reset_all")
+        Foobara.raise_if_production!
         Entity::Concerns::Callbacks.reset_all
 
         install!

--- a/projects/entities/projects/entity/src/concerns/callbacks.rb
+++ b/projects/entities/projects/entity/src/concerns/callbacks.rb
@@ -8,7 +8,7 @@ module Foobara
 
         class << self
           def reset_all
-            Foobara.raise_if_production!("reset_all")
+            Foobara.raise_if_production!
             Entity.instance_variable_set("@class_callback_registry", nil)
           end
         end

--- a/projects/entities/projects/model/lib/foobara/model.rb
+++ b/projects/entities/projects/model/lib/foobara/model.rb
@@ -30,7 +30,7 @@ module Foobara
       end
 
       def reset_all
-        Foobara.raise_if_production!("reset_all")
+        Foobara.raise_if_production!
         install!
       end
     end

--- a/projects/entities/projects/persistence/lib/foobara/persistence.rb
+++ b/projects/entities/projects/persistence/lib/foobara/persistence.rb
@@ -4,7 +4,7 @@ module Foobara
   module Persistence
     class << self
       def reset_all
-        Foobara.raise_if_production!("reset_all")
+        Foobara.raise_if_production!
         @tables_for_entity_class_name = @bases = @default_crud_driver = @default_base = nil
         EntityBase::Transaction::Concerns::EntityCallbackHandling.reset_all
         EntityBase::Transaction.reset_all

--- a/projects/entities/projects/persistence/src/entity_base/transaction/concerns/entity_callback_handling.rb
+++ b/projects/entities/projects/persistence/src/entity_base/transaction/concerns/entity_callback_handling.rb
@@ -10,7 +10,7 @@ module Foobara
           module EntityCallbackHandling
             class << self
               def reset_all
-                Foobara.raise_if_production!("reset_all")
+                Foobara.raise_if_production!
                 install!
               end
 

--- a/projects/entities/projects/persistence/src/entity_base/transaction/concerns/transaction_tracking.rb
+++ b/projects/entities/projects/persistence/src/entity_base/transaction/concerns/transaction_tracking.rb
@@ -23,7 +23,7 @@ module Foobara
               end
 
               def reset_all
-                Foobara.raise_if_production!("reset_all")
+                Foobara.raise_if_production!
                 @open_transactions = nil
               end
 

--- a/projects/typesystem/projects/builtin_types/lib/foobara/builtin_types.rb
+++ b/projects/typesystem/projects/builtin_types/lib/foobara/builtin_types.rb
@@ -67,7 +67,7 @@ module Foobara
       end
 
       def reset_all
-        Foobara.raise_if_production!("reset_all")
+        Foobara.raise_if_production!
 
         builtin_types.each do |builtin_type|
           builtin_type.foobara_each do |scoped|

--- a/projects/typesystem/projects/project/src/foobara.rb
+++ b/projects/typesystem/projects/project/src/foobara.rb
@@ -57,7 +57,7 @@ module Foobara
 
     def raise_if_production!(method_name = nil)
       if method_name
-        warn "DEPRECATION WARNING: Passing method_name to Foobara.raise_if_production! is deprecated. It will be inferred automatically."
+        warn "DEPRECATION WARNING: Passing method_name is deprecated."
       else
         method_name = caller_locations.map(&:label).find { |label| !label.start_with?("block in") }
       end

--- a/projects/typesystem/projects/project/src/foobara.rb
+++ b/projects/typesystem/projects/project/src/foobara.rb
@@ -51,13 +51,19 @@ module Foobara
     end
 
     def reset_alls
-      raise_if_production!("reset_alls")
+      raise_if_production!
       all_projects.each_value(&:reset_all)
     end
 
-    def raise_if_production!(*)
+    def raise_if_production!(method_name = nil)
+      if method_name
+        warn "DEPRECATION WARNING: Passing method_name to Foobara.raise_if_production! is deprecated. It will be inferred automatically."
+      else
+        method_name = caller_locations.map(&:label).find { |label| !label.start_with?("block in") }
+      end
+
       if ENV["FOOBARA_ENV"].nil? || ENV["FOOBARA_ENV"] == "production"
-        raise MethodCantBeCalledInProductionError
+        raise MethodCantBeCalledInProductionError, method_name
       end
     end
   end

--- a/projects/typesystem/projects/project/src/project.rb
+++ b/projects/typesystem/projects/project/src/project.rb
@@ -36,7 +36,7 @@ module Foobara
     end
 
     def reset_all
-      Foobara.raise_if_production!("reset_all")
+      Foobara.raise_if_production!
 
       if self.module.respond_to?(:reset_all)
         self.module.reset_all

--- a/projects/typesystem/projects/type_declarations/lib/foobara/type_declarations.rb
+++ b/projects/typesystem/projects/type_declarations/lib/foobara/type_declarations.rb
@@ -5,7 +5,7 @@ module Foobara
     class << self
       def reset_all(skip_check: nil)
         unless skip_check
-          Foobara.raise_if_production!("reset_all")
+          Foobara.raise_if_production!
         end
 
         Util.descendants(Error).each do |error_class|

--- a/projects/typesystem/spec/foobara/foobara_spec.rb
+++ b/projects/typesystem/spec/foobara/foobara_spec.rb
@@ -1,14 +1,24 @@
 RSpec.describe Foobara do
   describe ".raise_if_production!" do
-    let(:method_name) { "reset_alls" }
+    def my_reset_method
+      described_class.raise_if_production!
+    end
 
     context "when FOOBARA_ENV is nil" do
       stub_env_var("FOOBARA_ENV", nil)
 
-      it "raises MethodCantBeCalledInProductionError" do
+      it "raises MethodCantBeCalledInProductionError and infers method name" do
         expect {
-          described_class.raise_if_production!(method_name)
-        }.to raise_error(Foobara::MethodCantBeCalledInProductionError)
+          my_reset_method
+        }.to raise_error(Foobara::MethodCantBeCalledInProductionError, "my_reset_method")
+      end
+
+      it "prints a deprecation warning if method name is passed explicitly" do
+        expect {
+          expect {
+            described_class.raise_if_production!("some_method")
+          }.to raise_error(Foobara::MethodCantBeCalledInProductionError, "some_method")
+        }.to output(/DEPRECATION WARNING/).to_stderr
       end
     end
 
@@ -17,8 +27,8 @@ RSpec.describe Foobara do
 
       it "raises MethodCantBeCalledInProductionError" do
         expect {
-          described_class.raise_if_production!(method_name)
-        }.to raise_error(Foobara::MethodCantBeCalledInProductionError)
+          my_reset_method
+        }.to raise_error(Foobara::MethodCantBeCalledInProductionError, "my_reset_method")
       end
     end
 
@@ -27,7 +37,7 @@ RSpec.describe Foobara do
 
       it "doesn't raise MethodCantBeCalledInProductionError" do
         expect {
-          described_class.raise_if_production!(method_name)
+          my_reset_method
         }.to_not raise_error
       end
     end
@@ -37,7 +47,7 @@ RSpec.describe Foobara do
 
       it "doesn't raise MethodCantBeCalledInProductionError" do
         expect {
-          described_class.raise_if_production!(method_name)
+          my_reset_method
         }.to_not raise_error
       end
     end

--- a/projects/typesystem/spec/foobara/foobara_spec.rb
+++ b/projects/typesystem/spec/foobara/foobara_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Foobara do
       it "raises MethodCantBeCalledInProductionError and infers method name" do
         expect {
           my_reset_method
-        }.to raise_error(Foobara::MethodCantBeCalledInProductionError, "my_reset_method")
+        }.to raise_error(Foobara::MethodCantBeCalledInProductionError, /my_reset_method/)
       end
 
       it "prints a deprecation warning if method name is passed explicitly" do
@@ -28,7 +28,7 @@ RSpec.describe Foobara do
       it "raises MethodCantBeCalledInProductionError" do
         expect {
           my_reset_method
-        }.to raise_error(Foobara::MethodCantBeCalledInProductionError, "my_reset_method")
+        }.to raise_error(Foobara::MethodCantBeCalledInProductionError, /my_reset_method/)
       end
     end
 


### PR DESCRIPTION
Closes #79 

I have resolved the issue by updating Foobara.raise_if_production! to automatically infer the calling method name instead of requiring it to be passed explicitly.

Changes made
Updated Foobara.raise_if_production! to accept an optional method_name argument
Added automatic inference of caller method using caller_locations when not provided
Added deprecation warning when method_name is passed explicitly
Passed inferred method_name into MethodCantBeCalledInProductionError for better error context
Refactored all call sites (~12 locations) to remove hard-coded method name strings
Updated tests (foobara_spec.rb) to validate inferred behavior and deprecation warning

Summary
This removes hard-coded method name dependencies, reduces duplication, and keeps backward compatibility while encouraging the new inferred approach.