### PR TITLE
Replace .first and .last with [0] and [-1] for performance (#76)

### DIFF
--- a/projects/command/src/command_pattern_implementation/concerns/command_data.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/command_data.rb
@@ -9,7 +9,7 @@ module Foobara
             if args.empty?
               @description
             elsif args.size == 1
-              @description = args.first
+              @description = args[0]
             else
               # :nocov:
               raise ArgumentError, "wrong number of arguments (#{args.size} for 0 or 1)"

--- a/projects/command/src/command_pattern_implementation/concerns/errors.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/errors.rb
@@ -66,7 +66,7 @@ module Foobara
 
         def add_input_error(*args, **opts)
           error = if args.size == 1 && opts.empty?
-                    error = args.first
+                    error = args[0]
 
                     unless error.is_a?(Value::DataError)
                       # :nocov:
@@ -75,8 +75,8 @@ module Foobara
                     end
 
                     error
-                  elsif args.empty? || (args.size == 1 && args.first.is_a?(Hash))
-                    error_args = opts.merge(args.first || {})
+                  elsif args.empty? || (args.size == 1 && args[0].is_a?(Hash))
+                    error_args = opts.merge(args[0] || {})
                     symbol = error_args[:symbol]
                     path = error_args[:input] || error_args[:path]
 
@@ -126,9 +126,9 @@ module Foobara
 
         def add_runtime_error(*args, halt: true, **opts)
           error = if args.size == 1 && opts.empty? && (
-            args.first.is_a?(::Class) || args.first.is_a?(Foobara::RuntimeError)
+            args[0].is_a?(::Class) || args[0].is_a?(Foobara::RuntimeError)
           )
-                    error = args.first
+                    error = args[0]
 
                     if error.is_a?(::Class) && error < Foobara::RuntimeError
                       error = error.new
@@ -142,8 +142,8 @@ module Foobara
                     end
 
                     error
-                  elsif args.empty? || (args.size == 1 && args.first.is_a?(Hash))
-                    error_args = opts.merge(args.first || {})
+                  elsif args.empty? || (args.size == 1 && args[0].is_a?(Hash))
+                    error_args = opts.merge(args[0] || {})
                     symbol = error_args[:symbol]
 
                     unless symbol

--- a/projects/command/src/command_pattern_implementation/concerns/errors_type.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/errors_type.rb
@@ -26,7 +26,7 @@ module Foobara
           def possible_error(*args)
             possible_error = case args.size
                              when 1
-                               arg = args.first
+                               arg = args[0]
 
                                if arg.is_a?(PossibleError)
                                  # TODO: test this code path

--- a/projects/command/src/command_pattern_implementation/concerns/subcommands.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/subcommands.rb
@@ -74,7 +74,7 @@ module Foobara
             end
 
             if subcommand_classes.length == 1
-              subcommand_classes = Util.array(subcommand_classes.first)
+              subcommand_classes = Util.array(subcommand_classes[0])
             end
 
             subcommand_classes.each do |subcommand_class|

--- a/projects/command_connectors/src/command_connector.rb
+++ b/projects/command_connectors/src/command_connector.rb
@@ -51,7 +51,7 @@ module Foobara
       def to_authenticator(*args)
         symbol, object = case args.size
                          when 1
-                           [nil, args.first]
+                           [nil, args[0]]
                          when 2
                            args
                          else
@@ -97,7 +97,7 @@ module Foobara
             nil
             # :nocov:
           when 1
-            to_authenticator(object.first)
+            to_authenticator(object[0])
           else
             authenticators = object.map { |authenticatorish| to_authenticator(authenticatorish) }
             AuthenticatorSelector.new(authenticators:, symbol:)
@@ -133,13 +133,13 @@ module Foobara
             size = element_types.size
 
             first_required_input = if size == 1
-                                     element_types.keys.first
+                                     element_types.keys[0]
                                    elsif size > 1
                                      declaration = inputs_type&.declaration_data
                                      required_attribute_names = declaration&.[](:required) || EMPTY_ARRAY
 
                                      if required_attribute_names.size == 1
-                                       required_attribute_names.first
+                                       required_attribute_names[0]
                                      else
                                        # :nocov:
                                        raise ArgumentError,
@@ -262,7 +262,7 @@ module Foobara
     def connect(*args, **opts)
       args, opts = desugarize_connect_args(args, opts)
 
-      registerable = args.first
+      registerable = args[0]
 
       if opts.key?(:authenticator)
         authenticator = opts[:authenticator]

--- a/projects/command_connectors/src/command_connector/concerns/desugarizers.rb
+++ b/projects/command_connectors/src/command_connector/concerns/desugarizers.rb
@@ -28,7 +28,7 @@ module Foobara
             when 1
               # TODO: test this code path by removing all desugarizers in a spec.
               # :nocov:
-              processors.first
+              processors[0]
               # :nocov:
             else
               Value::Processor::Pipeline.new(processors:)

--- a/projects/command_connectors/src/command_connector/request.rb
+++ b/projects/command_connectors/src/command_connector/request.rb
@@ -108,7 +108,7 @@ module Foobara
         actual_serializers = objects_to_serializers(serializers)
 
         @serializer = if actual_serializers.size == 1
-                        actual_serializers.first
+                        actual_serializers[0]
                       else
                         Value::Processor::Pipeline.new(processors: actual_serializers)
                       end

--- a/projects/command_connectors/src/command_registry.rb
+++ b/projects/command_connectors/src/command_registry.rb
@@ -226,7 +226,7 @@ module Foobara
     def to_allowed_rule(*args)
       symbol, object = case args.size
                        when 1
-                         [nil, args.first]
+                         [nil, args[0]]
                        when 2
                          args
                        else

--- a/projects/command_connectors/src/desugarizers/attributes.rb
+++ b/projects/command_connectors/src/desugarizers/attributes.rb
@@ -46,7 +46,7 @@ module Foobara
             end
           end
 
-          transformers = transformers.first unless is_array
+          transformers = transformers[0] unless is_array
 
           opts = opts.merge(opts_key => transformers)
 

--- a/projects/command_connectors/src/desugarizers/auth.rb
+++ b/projects/command_connectors/src/desugarizers/auth.rb
@@ -3,7 +3,7 @@ module Foobara
     module Desugarizers
       class Auth < Desugarizer
         def applicable?(args_and_opts)
-          args_and_opts.last.key?(:auth)
+          args_and_opts[-1].key?(:auth)
         end
 
         def desugarize(args_and_opts)

--- a/projects/command_connectors/src/desugarizers/set_inputs.rb
+++ b/projects/command_connectors/src/desugarizers/set_inputs.rb
@@ -36,7 +36,7 @@ module Foobara
             end
           end
 
-          transformers = transformers.first unless is_array
+          transformers = transformers[0] unless is_array
 
           opts = opts.merge(inputs_transformers: transformers)
 

--- a/projects/command_connectors/src/transformed_command.rb
+++ b/projects/command_connectors/src/transformed_command.rb
@@ -447,7 +447,7 @@ module Foobara
         end
 
         @inputs_transformer = if transformers.size == 1
-                                transformers.first
+                                transformers[0]
                               else
                                 Value::Processor::Pipeline.new(processors: transformers)
                               end
@@ -468,7 +468,7 @@ module Foobara
           transformers = transformers_to_processors(response_mutators, result_type_from_transformers, direction: :from)
 
           if transformers.size == 1
-            transformers.first
+            transformers[0]
           else
             Value::Processor::Pipeline.new(processors: transformers)
           end
@@ -490,7 +490,7 @@ module Foobara
           transformers = transformers_to_processors(request_mutators, inputs_type_from_transformers, direction: :to)
 
           if transformers.size == 1
-            transformers.first
+            transformers[0]
           else
             Value::Processor::Pipeline.new(processors: transformers)
           end
@@ -515,7 +515,7 @@ module Foobara
           transformers = transformers_to_processors(result_transformers, command_class.result_type, direction: :from)
 
           if transformers.size == 1
-            transformers.first
+            transformers[0]
           else
             Value::Processor::Pipeline.new(processors: transformers)
           end
@@ -729,7 +729,7 @@ module Foobara
       transformers = self.class.transformers_to_processors(serializers, nil, declaration_data: self)
 
       if transformers.size == 1
-        transformers.first
+        transformers[0]
       else
         Value::Processor::Pipeline.new(processors: transformers)
       end
@@ -742,7 +742,7 @@ module Foobara
                                                                                      declaration_data: self)
 
       if transformers.size == 1
-        transformers.first
+        transformers[0]
       else
         Value::Processor::Pipeline.new(processors: transformers)
       end
@@ -759,7 +759,7 @@ module Foobara
       )
 
       if transformers.size == 1
-        transformers.first
+        transformers[0]
       else
         Value::Processor::Pipeline.new(processors: transformers)
       end

--- a/projects/domain_mapper/src/domain_mapper.rb
+++ b/projects/domain_mapper/src/domain_mapper.rb
@@ -86,7 +86,7 @@ module Foobara
       # TODO: should this be somewhere more general-purpose?
       def args_to_type(*args, **opts, &block)
         if args.size == 1 && opts.empty? && block.nil?
-          object_to_type(args.first)
+          object_to_type(args[0])
         else
           domain.foobara_type_from_declaration(*args, **opts, &block)
         end

--- a/projects/domain_mapper/src/domain_mapper_lookups.rb
+++ b/projects/domain_mapper/src/domain_mapper_lookups.rb
@@ -83,7 +83,7 @@ module Foobara
           end
         end
 
-        value = candidates.first
+        value = candidates[0]
 
         return value if value
 

--- a/projects/entities/projects/detached_entity/src/concerns/associations.rb
+++ b/projects/entities/projects/detached_entity/src/concerns/associations.rb
@@ -65,7 +65,7 @@ module Foobara
                 end
 
                 unless values.empty?
-                  values.first
+                  values[0]
                 end
               end
             end
@@ -73,7 +73,7 @@ module Foobara
 
           def association_for(association_filters)
             if association_filters.size == 1
-              data_path = association_filters.first.to_s
+              data_path = association_filters[0].to_s
 
               if deep_associations.key?(data_path)
                 return data_path
@@ -93,7 +93,7 @@ module Foobara
               raise "Multiple associations matched by #{association_filters}"
               # :nocov:
             else
-              result.first
+              result[0]
             end
           end
 

--- a/projects/entities/projects/entity/src/concerns/persistence.rb
+++ b/projects/entities/projects/entity/src/concerns/persistence.rb
@@ -62,7 +62,7 @@ module Foobara
 
           attribute_name = if attribute_name_or_attributes.is_a?(::Hash)
                              if attribute_name_or_attributes.keys.size == 1
-                               attribute_name_or_attributes.keys.first.to_sym
+                               attribute_name_or_attributes.keys[0].to_sym
                              end
                            elsif attribute_name_or_attributes
                              attribute_name_or_attributes.to_sym

--- a/projects/entities/projects/entity/src/concerns/queries.rb
+++ b/projects/entities/projects/entity/src/concerns/queries.rb
@@ -57,7 +57,7 @@ module Foobara
 
             if load_paths
               if load_paths.is_a?(::Array)
-                first = load_paths.first
+                first = load_paths[0]
 
                 if first.is_a?(::Symbol) || (first.is_a?(::String) && !first.include?("."))
                   load_paths = [load_paths]
@@ -99,8 +99,8 @@ module Foobara
           end
 
           def load_many(*record_ids)
-            if record_ids.size == 1 && record_ids.first.is_a?(::Array)
-              record_ids = record_ids.first
+            if record_ids.size == 1 && record_ids[0].is_a?(::Array)
+              record_ids = record_ids[0]
             end
 
             current_transaction_table.load_many(record_ids)
@@ -125,7 +125,7 @@ module Foobara
 
             unless containing_records.empty?
               if containing_records.size == 1
-                containing_records.first
+                containing_records[0]
               else
                 # :nocov:
                 raise "Expected only one record to own #{record} but found #{containing_records.size}"
@@ -155,7 +155,7 @@ module Foobara
             end until owning_entity_class
 
             if attribute_path.size == 1
-              attribute_path = attribute_path.first
+              attribute_path = attribute_path[0]
             end
 
             if owning_entity_class == self

--- a/projects/entities/projects/entity/src/extensions/domain/domain_module_extension.rb
+++ b/projects/entities/projects/entity/src/extensions/domain/domain_module_extension.rb
@@ -34,7 +34,7 @@ module Foobara
                                             when 1, 2
                                               arg, other = args
 
-                                              if args.first.is_a?(::String)
+                                              if args[0].is_a?(::String)
                                                 [other, arg]
                                               else
                                                 args
@@ -59,7 +59,7 @@ module Foobara
             attributes_type = handler.type_for_declaration(attributes_type_declaration)
 
             # TODO: reuse the model_base_class primary key if it has one...
-            primary_key = attributes_type.element_types.keys.first
+            primary_key = attributes_type.element_types.keys[0]
 
             model_module = unless scoped_full_path.empty?
                              scoped_full_name

--- a/projects/entities/projects/model/src/concerns/classes.rb
+++ b/projects/entities/projects/model/src/concerns/classes.rb
@@ -61,7 +61,7 @@ module Foobara
                 model_module = Util.make_module_p(model_module_name, tag: true)
               end
 
-              const_name = model_name.split("::").last
+              const_name = model_name.split("::")[-1]
 
               model_module.const_set(const_name, anonymous_model_class)
 

--- a/projects/entities/projects/model/src/concerns/types.rb
+++ b/projects/entities/projects/model/src/concerns/types.rb
@@ -28,7 +28,7 @@ module Foobara
                 end
               end
             when 1
-              @mutable_override = args.first
+              @mutable_override = args[0]
               set_model_type
             else
               # :nocov:

--- a/projects/entities/projects/model/src/model.rb
+++ b/projects/entities/projects/model/src/model.rb
@@ -18,7 +18,7 @@ module Foobara
         when 0
           @description
         when 1
-          @description = args.first
+          @description = args[0]
         else
           # :nocov:
           raise ArgumentError, "expected 0 or 1 argument, got #{args.size}"
@@ -111,7 +111,7 @@ module Foobara
         if foobara_type&.scoped_path_set?
           foobara_type.scoped_name
         else
-          Util.non_full_name(self) || model_name&.split("::")&.last
+          Util.non_full_name(self) || model_name&.split("::")&.[](-1)
         end
       end
 

--- a/projects/entities/projects/persistence/src/entity_base.rb
+++ b/projects/entities/projects/persistence/src/entity_base.rb
@@ -10,7 +10,7 @@ module Foobara
           if existing_transactions.empty?
             block.call
           elsif existing_transactions.size == 1
-            existing_transaction = existing_transactions.first
+            existing_transaction = existing_transactions[0]
 
             existing_transaction.entity_base.using_transaction(existing_transaction, &block)
           else

--- a/projects/entities/projects/persistence/src/entity_base/transaction.rb
+++ b/projects/entities/projects/persistence/src/entity_base/transaction.rb
@@ -148,7 +148,7 @@ module Foobara
         end
 
         def load_aggregate(record)
-          load_aggregates([record]).first
+          load_aggregates([record])[0]
         end
 
         def track_unloaded_thunk(entity)

--- a/projects/entities/projects/persistence/src/persistence.rb
+++ b/projects/entities/projects/persistence/src/persistence.rb
@@ -38,7 +38,7 @@ module Foobara
         end
 
         if bases.size == 1
-          bases.first.transaction(mode, &)
+          bases[0].transaction(mode, &)
         else
           Foobara::TransactionGroup.run(bases:, mode:, &)
         end
@@ -86,7 +86,7 @@ module Foobara
           # :nocov:
         end
 
-        bases.first
+        bases[0]
       end
 
       def to_bases(object)
@@ -157,7 +157,7 @@ module Foobara
       def register_base(*args, name: nil, table_prefix: nil)
         base = case args
                in [EntityBase]
-                 args.first
+                 args[0]
                in [Class => crud_driver_class, *rest] if crud_driver_class < EntityAttributesCrudDriver
                  unless name
                    # :nocov:

--- a/projects/entities_plumbing/src/extensions/command_pattern_implementation/concerns/entities.rb
+++ b/projects/entities_plumbing/src/extensions/command_pattern_implementation/concerns/entities.rb
@@ -64,7 +64,7 @@ module Foobara
           begin
             # here... filter out created entities...
             if thunks_to_load.size == 1
-              entity_class.load(thunks_to_load.first)
+              entity_class.load(thunks_to_load[0])
             else
               entity_class.load_many(thunks_to_load)
             end

--- a/projects/manifest/src/base_manifest.rb
+++ b/projects/manifest/src/base_manifest.rb
@@ -91,11 +91,11 @@ module Foobara
       end
 
       def parent_category
-        self[:parent]&.first
+        self[:parent]&.[](0)
       end
 
       def parent_name
-        self[:parent]&.last
+        self[:parent]&.[](-1)
       end
 
       def scoped_category
@@ -103,7 +103,7 @@ module Foobara
       end
 
       def relevant_manifest
-        @relevant_manifest ||= Foobara::DataPath.values_at(manifest_path, root_manifest).first
+        @relevant_manifest ||= Foobara::DataPath.values_at(manifest_path, root_manifest)[0]
       end
 
       def find_type(type_declaration)

--- a/projects/manifest/src/type.rb
+++ b/projects/manifest/src/type.rb
@@ -69,7 +69,7 @@ module Foobara
           # :nocov:
         end
 
-        target_classes.first
+        target_classes[0]
       end
 
       def types_depended_on

--- a/projects/typesystem/projects/callback/src/block.rb
+++ b/projects/typesystem/projects/callback/src/block.rb
@@ -50,7 +50,7 @@ module Foobara
       end
 
       def takes_block?
-        @takes_block ||= original_block.parameters.last&.first&.==(:block) || false
+        @takes_block ||= original_block.parameters[-1]&.[](0)&.==(:block) || false
       end
 
       def has_one_or_zero_positional_args?

--- a/projects/typesystem/projects/callback/src/registry/multiple_action.rb
+++ b/projects/typesystem/projects/callback/src/registry/multiple_action.rb
@@ -73,7 +73,7 @@ module Foobara
           when 0
             nil
           when 1
-            action = actions.first
+            action = actions[0]
             validate_action!(action)
             action
           else
@@ -84,7 +84,7 @@ module Foobara
         end
 
         def normalize_actions(actions, validate = true)
-          first = actions.first
+          first = actions[0]
 
           if first.is_a?(Array)
             if actions.size == 1

--- a/projects/typesystem/projects/common/src/data_path.rb
+++ b/projects/typesystem/projects/common/src/data_path.rb
@@ -103,7 +103,7 @@ module Foobara
 
     def prepend!(*prepend_parts)
       if prepend_parts.size == 1
-        arg = prepend_parts.first
+        arg = prepend_parts[0]
 
         if arg.is_a?(Array)
           prepend_parts = arg
@@ -122,7 +122,7 @@ module Foobara
 
     def append!(*append_parts)
       if append_parts.size == 1
-        arg = append_parts.first
+        arg = append_parts[0]
 
         if arg.is_a?(Array)
           append_parts = arg
@@ -174,12 +174,12 @@ module Foobara
         raise TooManyValuesAtPathError.new(path, values)
       end
 
-      values.first
+      values[0]
     end
 
     def set_value_at(object, value, parts = path)
       owner = value_at(object, parts[0..-2])
-      index = parts.last
+      index = parts[-1]
 
       if owner.is_a?(::Hash)
         if owner.key?(index.to_s)
@@ -206,7 +206,7 @@ module Foobara
     # Helper method that determines if the path points to an array and none of the atoms along the way are also arrays.
     # And that there's at least one atom (we are going to consider a collection to be "named" not an anonymous array.)
     def simple_collection?
-      path.size > 1 && path.last == :"#" && path[0..-2].none? { |part| part == :"#" }
+      path.size > 1 && path[-1] == :"#" && path[0..-2].none? { |part| part == :"#" }
     end
 
     def ==(other)
@@ -214,7 +214,7 @@ module Foobara
     end
 
     def last
-      path.last
+      path[-1]
     end
 
     def empty?

--- a/projects/typesystem/projects/common/src/error.rb
+++ b/projects/typesystem/projects/common/src/error.rb
@@ -27,7 +27,7 @@ module Foobara
         when 0
           Util.non_full_name_underscore(self).gsub(/_error$/, "").to_sym
         when 1
-          arg = args.first
+          arg = args[0]
           singleton_class.define_method :symbol do
             arg
           end
@@ -58,7 +58,7 @@ module Foobara
         when 0
           Util.humanize(symbol.to_s)
         when 1
-          arg = args.first
+          arg = args[0]
           singleton_class.define_method :message do
             arg
           end
@@ -79,7 +79,7 @@ module Foobara
         when 0
           {}
         when 1
-          arg = args.first
+          arg = args[0]
           singleton_class.define_method :context_type_declaration do
             arg
           end

--- a/projects/typesystem/projects/common/src/error_key.rb
+++ b/projects/typesystem/projects/common/src/error_key.rb
@@ -74,7 +74,7 @@ module Foobara
 
     def prepend_path!(*prepend_parts)
       if prepend_parts.size == 1
-        arg = prepend_parts.first
+        arg = prepend_parts[0]
 
         if arg.is_a?(Array)
           prepend_parts = arg

--- a/projects/typesystem/projects/common/src/outcome.rb
+++ b/projects/typesystem/projects/common/src/outcome.rb
@@ -88,7 +88,7 @@ module Foobara
     def raise!
       return if success?
 
-      error = error_collection.first
+      error = error_collection[0]
       original_backtrace = error.backtrace_when_initialized
 
       if error_collection.size > 1

--- a/projects/typesystem/projects/domain/src/domain_module_extension.rb
+++ b/projects/typesystem/projects/domain/src/domain_module_extension.rb
@@ -20,7 +20,7 @@ module Foobara
         def foobara_domain_map(*args, to: nil, strict: false, criteria: nil, should_raise: false, **opts)
           case args.size
           when 1
-            value = args.first
+            value = args[0]
           when 0
             if opts.empty?
               # :nocov:
@@ -110,8 +110,8 @@ module Foobara
         end
 
         def foobara_type_from_declaration(*args, **opts, &block)
-          if opts.empty? && block.nil? && args.size == 1 && args.first.is_a?(Types::Type)
-            return args.first
+          if opts.empty? && block.nil? && args.size == 1 && args[0].is_a?(Types::Type)
+            return args[0]
           end
 
           Foobara::Namespace.use self do
@@ -132,8 +132,8 @@ module Foobara
         end
 
         def foobara_register_type(type_symbol, *type_declaration_bits, &block)
-          type = if block.nil? && type_declaration_bits.size == 1 && type_declaration_bits.first.is_a?(Types::Type)
-                   type_declaration_bits.first
+          type = if block.nil? && type_declaration_bits.size == 1 && type_declaration_bits[0].is_a?(Types::Type)
+                   type_declaration_bits[0]
                  else
                    foobara_type_from_declaration(*type_declaration_bits, &block)
                  end
@@ -201,7 +201,7 @@ module Foobara
           end
 
           if domains.length == 1
-            domains = Util.array(domains.first)
+            domains = Util.array(domains[0])
           end
 
           domains.each do |domain|

--- a/projects/typesystem/projects/enumerated/src/values.rb
+++ b/projects/typesystem/projects/enumerated/src/values.rb
@@ -72,7 +72,7 @@ module Foobara
         elsif args.size > 1
           initialize(args)
         else
-          symbol_map = args.first
+          symbol_map = args[0]
 
           case symbol_map
           when ::Hash

--- a/projects/typesystem/projects/namespace/src/ambiguous_registry.rb
+++ b/projects/typesystem/projects/namespace/src/ambiguous_registry.rb
@@ -82,7 +82,7 @@ module Foobara
                   "Ambiguous match for #{path.inspect}. Matches the following: #{candidates.inspect}"
           end
 
-          candidates.first
+          candidates[0]
         end
       end
 

--- a/projects/typesystem/projects/namespace/src/is_namespace.rb
+++ b/projects/typesystem/projects/namespace/src/is_namespace.rb
@@ -187,7 +187,7 @@ module Foobara
             # :nocov:
           end
 
-          scoped = candidates.first ||
+          scoped = candidates[0] ||
                    foobara_parent_namespace&.foobara_lookup_without_cache(path, filter:, mode:, visited:)
 
           scoped ||= foobara_lookup_without_cache(
@@ -295,7 +295,7 @@ module Foobara
           # :nocov:
         end
 
-        candidates.first || partial
+        candidates[0] || partial
       end
 
       def foobara_parent_namespace

--- a/projects/typesystem/projects/namespace/src/prefixless_registry.rb
+++ b/projects/typesystem/projects/namespace/src/prefixless_registry.rb
@@ -33,7 +33,7 @@ module Foobara
 
       def lookup(path, filter = nil)
         if path.size == 1
-          apply_filter(registry[path.first], filter)
+          apply_filter(registry[path[0]], filter)
         end
       end
 

--- a/projects/typesystem/projects/namespace/src/scoped.rb
+++ b/projects/typesystem/projects/namespace/src/scoped.rb
@@ -62,7 +62,7 @@ module Foobara
     end
 
     def scoped_short_name
-      @scoped_short_name ||= scoped_path.last
+      @scoped_short_name ||= scoped_path[-1]
     end
 
     def scoped_short_path

--- a/projects/typesystem/projects/state_machine/src/sugar.rb
+++ b/projects/typesystem/projects/state_machine/src/sugar.rb
@@ -85,7 +85,7 @@ module Foobara
               } but should have been one of #{states}"
             end
           else
-            self.initial_state = states.first
+            self.initial_state = states[0]
           end
         end
 

--- a/projects/typesystem/projects/type_declarations/src/dsl/attributes.rb
+++ b/projects/typesystem/projects/type_declarations/src/dsl/attributes.rb
@@ -65,7 +65,7 @@ module Foobara
             if block
               # TODO: technically, current namespace might have an overridden :array type so instead we
               # should lookup :array he to see if we get BuiltinTypes[:array] or not (or "::array" or not)
-              if processor_symbols.first == :array
+              if processor_symbols[0] == :array
                 type, *processor_symbols = processor_symbols
               end
             else

--- a/projects/typesystem/projects/type_declarations/src/handlers/extend_array_type_declaration/array_desugarizer.rb
+++ b/projects/typesystem/projects/type_declarations/src/handlers/extend_array_type_declaration/array_desugarizer.rb
@@ -20,7 +20,7 @@ module Foobara
             strict_type_declaration.is_absolutified = true
 
             unless sugary_type_declaration.empty?
-              element_type_declaration = sugary_type_declaration.first
+              element_type_declaration = sugary_type_declaration[0]
 
               element_type_declaration = if element_type_declaration.is_a?(Types::Type)
                                            element_type_declaration.reference_or_declaration_data

--- a/projects/typesystem/projects/type_declarations/src/type_builder.rb
+++ b/projects/typesystem/projects/type_declarations/src/type_builder.rb
@@ -40,7 +40,7 @@ module Foobara
             raise ArgumentError, "expected 1 argument or a block but got 0 arguments and no block"
             # :nocov:
           when 1
-            arg = args.first
+            arg = args[0]
 
             if arg.is_a?(TypeDeclaration)
               arg

--- a/projects/typesystem/projects/types/src/extensions/error.rb
+++ b/projects/typesystem/projects/types/src/extensions/error.rb
@@ -3,7 +3,7 @@ module Foobara
     class << self
       def types_depended_on(*args)
         if args.size == 1
-          context_type.types_depended_on(args.first)
+          context_type.types_depended_on(args[0])
         elsif args.empty?
           begin
             if context_type

--- a/projects/typesystem/projects/types/src/type.rb
+++ b/projects/typesystem/projects/types/src/type.rb
@@ -198,7 +198,7 @@ module Foobara
           # :nocov:
         end
 
-        target_classes.first
+        target_classes[0]
       end
 
       def extends?(type)

--- a/projects/typesystem/projects/value/src/data_error.rb
+++ b/projects/typesystem/projects/value/src/data_error.rb
@@ -15,7 +15,7 @@ module Foobara
       def attribute_name
         # TODO: feels awkward... something is not right
         # how is path actually set?
-        path.last || context[:attribute_name]
+        path[-1] || context[:attribute_name]
       end
 
       def eql?(other)

--- a/projects/typesystem/projects/value/src/processor.rb
+++ b/projects/typesystem/projects/value/src/processor.rb
@@ -125,7 +125,7 @@ module Foobara
             # :nocov:
           end
 
-          @error_class = error_classes.first
+          @error_class = error_classes[0]
         end
 
         def symbol
@@ -164,7 +164,7 @@ module Foobara
         end
 
         if requires_parent_declaration_data?
-          self.parent_declaration_data = args.first
+          self.parent_declaration_data = args[0]
         end
       end
 

--- a/projects/typesystem/projects/value/src/processor/selection.rb
+++ b/projects/typesystem/projects/value/src/processor/selection.rb
@@ -61,7 +61,7 @@ module Foobara
                           )
                         end
 
-                        applicable_processors.first
+                        applicable_processors[0]
                       else
                         processors.find { |processor| processor.applicable?(value) }
                       end


### PR DESCRIPTION
As recommended in "Polished Ruby Programming", replace Array#first and Array#last calls with bracket notation for a minor performance improvement.

Skipped cases where the receiver is not an Array (Set, Enumerator::Lazy, DataPath, or objects with custom #first/#last methods).