### PR TITLE
Use Object#__send__ for reflective calls

### DIFF
--- a/projects/command/src/command_pattern_implementation/concerns/runtime.rb
+++ b/projects/command/src/command_pattern_implementation/concerns/runtime.rb
@@ -114,7 +114,7 @@ module Foobara
             transition = transition_or_transitions
 
             state_machine.perform_transition!(transition) do
-              result = send(transition)
+              result = __send__(transition)
               halt! if has_errors?
             end
           end

--- a/projects/command_connectors/spec/command_connector_spec.rb
+++ b/projects/command_connectors/spec/command_connector_spec.rb
@@ -2039,7 +2039,7 @@ RSpec.describe Foobara::CommandConnector do
 
         # TODO: figure out how to set up this situation instead of directly passing a manifest
         # hash to a private method
-        patched_up_manifest = command_connector.send(
+        patched_up_manifest = command_connector.__send__(
           :patch_up_broken_parents_for_errors_with_missing_command_parents,
           manifest_hash
         )

--- a/projects/command_connectors/src/desugarizers/attributes.rb
+++ b/projects/command_connectors/src/desugarizers/attributes.rb
@@ -40,7 +40,7 @@ module Foobara
           transformers = transformers.map do |transformer|
             if transformer.is_a?(::Hash) && transformer.key?(desugarizer_symbol)
               params = transformer[desugarizer_symbol]
-              AttributesTransformers.send(transformer_method, *params)
+              AttributesTransformers.__send__(transformer_method, *params)
             else
               transformer
             end

--- a/projects/command_connectors/src/transformed_command.rb
+++ b/projects/command_connectors/src/transformed_command.rb
@@ -790,7 +790,7 @@ module Foobara
       if auth_mapped_method?(method_name)
         auth_mapped_value_for(method_name)
       elsif command.respond_to?(method_name)
-        command.send(method_name, ...)
+        command.__send__(method_name, ...)
       else
         # :nocov:
         super

--- a/projects/command_connectors/src/transformers/load_delegated_attributes_entities_pre_commit_transformer.rb
+++ b/projects/command_connectors/src/transformers/load_delegated_attributes_entities_pre_commit_transformer.rb
@@ -20,7 +20,7 @@ module Foobara
           case object
           when Entity
             object.class.delegates.each_key do |delegated_attribute_name|
-              object.send(delegated_attribute_name)
+              object.__send__(delegated_attribute_name)
             end
           when Array
             object.each do |element|

--- a/projects/entities/projects/detached_entity/src/concerns/associations.rb
+++ b/projects/entities/projects/detached_entity/src/concerns/associations.rb
@@ -196,7 +196,7 @@ module Foobara
               target_class = type.target_class
 
               method = target_class.respond_to?(:foobara_attributes_type) ? :foobara_attributes_type : :attributes_type
-              attributes_type = target_class.send(method)
+              attributes_type = target_class.__send__(method)
 
               if !remove_sensitive || !attributes_type.sensitive?
                 construct_associations(attributes_type, path, result, initial: false)

--- a/projects/entities/projects/detached_entity/src/extensions/builtin_types/detached_entity/casters/primary_key.rb
+++ b/projects/entities/projects/detached_entity/src/extensions/builtin_types/detached_entity/casters/primary_key.rb
@@ -26,7 +26,7 @@ module Foobara
           end
 
           def transform(primary_key)
-            entity_class.send(build_method, primary_key)
+            entity_class.__send__(build_method, primary_key)
           end
 
           def applies_message

--- a/projects/entities/projects/entity/src/sensitive_value_removers/entity.rb
+++ b/projects/entities/projects/entity/src/sensitive_value_removers/entity.rb
@@ -8,7 +8,10 @@ module Foobara
           elsif record.persisted?
             # We will assume that we do not need to clean up the primary key itself as
             # we will assume we don't allow sensitive primary keys for now.
-            thunkish = to_type.target_class.send(build_method, record.class.primary_key_attribute => record.primary_key)
+            thunkish = to_type.target_class.__send__(
+              build_method,
+              record.class.primary_key_attribute => record.primary_key
+            )
             thunkish.skip_validations = true
             thunkish.mutable = false
             thunkish

--- a/projects/entities/projects/model_attribute_helpers/src/attribute_helper_aliases.rb
+++ b/projects/entities/projects/model_attribute_helpers/src/attribute_helper_aliases.rb
@@ -20,7 +20,7 @@ module Foobara
             :type_declaration_value_at
           ].each do |method_name|
             define_method method_name do |*args, **opts, &block|
-              send("foobara_#{method_name}", *args, **opts, &block)
+              __send__("foobara_#{method_name}", *args, **opts, &block)
             end
           end
         end

--- a/projects/entities/projects/weak_object_set/src/weak_object_set.rb
+++ b/projects/entities/projects/weak_object_set/src/weak_object_set.rb
@@ -171,7 +171,7 @@ module Foobara
 
         if existing_object
           if key_method
-            key = object.send(key_method)
+            key = object.__send__(key_method)
             old_key = object_id_to_key[object_id]
 
             if key != old_key
@@ -189,7 +189,7 @@ module Foobara
           garbage_cleaner.track(object)
 
           if key_method
-            key = object.send(key_method)
+            key = object.__send__(key_method)
 
             if key
               existing_record_object_id = key_to_object_id[key]

--- a/projects/entities/spec/builtin_types/detached_entity_spec.rb
+++ b/projects/entities/spec/builtin_types/detached_entity_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ":detached_entity" do
       :SomeOrg,
       :SomeDomain
     ].each do |const|
-      Object.send(:remove_const, const) if Object.const_defined?(const)
+      Object.__send__(:remove_const, const) if Object.const_defined?(const)
     end
   end
 

--- a/projects/entities/spec/builtin_types/entity_spec.rb
+++ b/projects/entities/spec/builtin_types/entity_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ":entity" do
       :SomeOrg,
       :SomeDomain
     ].each do |const|
-      Object.send(:remove_const, const) if Object.const_defined?(const)
+      Object.__send__(:remove_const, const) if Object.const_defined?(const)
     end
   end
 

--- a/projects/entities/spec/builtin_types/model_spec.rb
+++ b/projects/entities/spec/builtin_types/model_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ":model" do
       :SomeOrg,
       :SomeDomain
     ].each do |const|
-      Object.send(:remove_const, const) if Object.const_defined?(const)
+      Object.__send__(:remove_const, const) if Object.const_defined?(const)
     end
   end
 

--- a/projects/entities/spec/entity/extending_existing_spec.rb
+++ b/projects/entities/spec/entity/extending_existing_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Foobara::Model do
   after do
     Foobara.reset_alls
     if Object.const_defined?(:User)
-      Object.send(:remove_const, :User)
+      Object.__send__(:remove_const, :User)
     end
   end
 

--- a/projects/entities/spec/entity/from_type_declaration_spec.rb
+++ b/projects/entities/spec/entity/from_type_declaration_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Foobara::Entity do
     after do
       Foobara.reset_alls
 
-      Object.send(:remove_const, :User) if Object.const_defined?(:User)
+      Object.__send__(:remove_const, :User) if Object.const_defined?(:User)
     end
 
     let(:declaration_data) do

--- a/projects/entities/spec/model/model_spec.rb
+++ b/projects/entities/spec/model/model_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Foobara::Model do
       :SomeEntity,
       :Foo
     ].each do |const|
-      Object.send(:remove_const, const) if Object.const_defined?(const)
+      Object.__send__(:remove_const, const) if Object.const_defined?(const)
     end
   end
 
@@ -117,7 +117,7 @@ RSpec.describe Foobara::Model do
 
       after do
         if Object.const_defined?(:Foo)
-          Object.send(:remove_const, :Foo)
+          Object.__send__(:remove_const, :Foo)
         end
       end
 

--- a/projects/typesystem/projects/builtin_types/src/email/validator_base.rb
+++ b/projects/typesystem/projects/builtin_types/src/email/validator_base.rb
@@ -46,7 +46,7 @@ module Foobara
         end
 
         def validation_errors(email)
-          build_error if email.send(negate_regex? ? :=~ : :!~, regex)
+          build_error if email.__send__(negate_regex? ? :=~ : :!~, regex)
         end
       end
 

--- a/projects/typesystem/projects/callback/src/set.rb
+++ b/projects/typesystem/projects/callback/src/set.rb
@@ -7,7 +7,7 @@ module Foobara
         self.callbacks = {}
 
         callback_hash.each do |type, blocks|
-          send("#{type}=", blocks.dup)
+          __send__("#{type}=", blocks.dup)
         end
       end
 
@@ -33,7 +33,7 @@ module Foobara
       end
 
       def [](type)
-        send(type)
+        __send__(type)
       end
 
       Block.types.each do |type|
@@ -46,11 +46,11 @@ module Foobara
         end
 
         define_method "each_#{type}" do |&block|
-          send(type).each(&block)
+          __send__(type).each(&block)
         end
 
         define_method "has_#{type}_callbacks?" do
-          !send(type).empty?
+          !__send__(type).empty?
         end
       end
     end

--- a/projects/typesystem/projects/common/src/data_path.rb
+++ b/projects/typesystem/projects/common/src/data_path.rb
@@ -192,7 +192,7 @@ module Foobara
       else
         method = "#{index}="
         if owner.respond_to?(method)
-          owner.send(method, value)
+          owner.__send__(method, value)
         else
           # :nocov:
           raise BadPathError, "Bad path: #{parts}"
@@ -274,7 +274,7 @@ module Foobara
                         object[path_part]
                       end
                     else
-                      object.send(path_part)
+                      object.__send__(path_part)
                     end
                   end
                 when Integer

--- a/projects/typesystem/projects/concerns/src/concern.rb
+++ b/projects/typesystem/projects/concerns/src/concern.rb
@@ -56,7 +56,7 @@ module Foobara
               if instance_variable_defined?(var_name)
                 instance_variable_get(var_name)
               else
-                superclass.send(name)
+                superclass.__send__(name)
               end
             end
 

--- a/projects/typesystem/projects/delegate/src/extensions/module.rb
+++ b/projects/typesystem/projects/delegate/src/extensions/module.rb
@@ -5,10 +5,10 @@ class Module
 
     method_names.each do |method_name|
       define_method method_name do |*args, **opts, &block|
-        target = to.is_a?(::Symbol) || to.is_a?(::String) ? send(to) : to
+        target = to.is_a?(::Symbol) || to.is_a?(::String) ? __send__(to) : to
         return nil if target.nil? && allow_nil
 
-        target.send(method_name, *args, **opts, &block)
+        target.__send__(method_name, *args, **opts, &block)
       end
     end
   end

--- a/projects/typesystem/projects/domain/src/domain.rb
+++ b/projects/typesystem/projects/domain/src/domain.rb
@@ -84,7 +84,7 @@ module Foobara
           if new_class.const_defined?(const_name)
             to_replace = new_class.const_get(const_name)
             if to_replace != value
-              new_class.send(:remove_const, const_name)
+              new_class.__send__(:remove_const, const_name)
               new_class.const_set(const_name, value)
             end
           else

--- a/projects/typesystem/projects/enumerated/src/values.rb
+++ b/projects/typesystem/projects/enumerated/src/values.rb
@@ -127,7 +127,7 @@ module Foobara
 
         [:all, :all_names, :all_values, :value?].each do |method_name|
           mod.singleton_class.define_method method_name do |*args, **opts, &block|
-            enumerated.send(method_name, *args, **opts, &block)
+            enumerated.__send__(method_name, *args, **opts, &block)
           end
         end
 

--- a/projects/typesystem/projects/model/src/concerns/classes.rb
+++ b/projects/typesystem/projects/model/src/concerns/classes.rb
@@ -42,7 +42,7 @@ module Foobara
                 if existing_class.instance_variable_get(:@foobara_created_via_make_class)
                   existing_module_to_copy_over = existing_class
                   parent_mod = Util.module_for(existing_class)
-                  parent_mod.send(:remove_const, Util.non_full_name(existing_class))
+                  parent_mod.__send__(:remove_const, Util.non_full_name(existing_class))
                 else
                   # :nocov:
                   return existing_class

--- a/projects/typesystem/projects/model/src/extensions/builtin_types/model/casters/hash.rb
+++ b/projects/typesystem/projects/model/src/extensions/builtin_types/model/casters/hash.rb
@@ -12,7 +12,7 @@ module Foobara
           def cast(attributes)
             symbolized_attributes = super
 
-            model_class.send(build_method(symbolized_attributes), symbolized_attributes)
+            model_class.__send__(build_method(symbolized_attributes), symbolized_attributes)
           end
 
           def model_class

--- a/projects/typesystem/projects/model/src/model.rb
+++ b/projects/typesystem/projects/model/src/model.rb
@@ -261,7 +261,7 @@ module Foobara
 
     def attributes_with_delegates
       h = self.class.delegates.keys.to_h do |delegated_attribute_name|
-        [delegated_attribute_name, send(delegated_attribute_name)]
+        [delegated_attribute_name, __send__(delegated_attribute_name)]
       end
 
       attributes.merge(h)

--- a/projects/typesystem/projects/model/src/sensitive_value_removers/model.rb
+++ b/projects/typesystem/projects/model/src/sensitive_value_removers/model.rb
@@ -12,7 +12,7 @@ module Foobara
           end
 
           Namespace.use(to_type.created_in_namespace) do
-            to_type.target_class.send(build_method, sanitized_attributes)
+            to_type.target_class.__send__(build_method, sanitized_attributes)
           end
         end
 

--- a/projects/typesystem/projects/namespace/src/is_namespace.rb
+++ b/projects/typesystem/projects/namespace/src/is_namespace.rb
@@ -356,7 +356,7 @@ module Foobara
 
         if filter
           method = "foobara_#{method}#{"!" if bang}"
-          send(method, *, **, filter:, &)
+          __send__(method, *, **, filter:, &)
         else
           # :nocov:
           super

--- a/projects/typesystem/projects/namespace/src/namespace.rb
+++ b/projects/typesystem/projects/namespace/src/namespace.rb
@@ -60,7 +60,7 @@ module Foobara
 
       def fire_changed!
         @on_change&.each_pair do |object, method_name|
-          object.send(method_name)
+          object.__send__(method_name)
         end
       end
 

--- a/projects/typesystem/projects/state_machine/src/state_machine.rb
+++ b/projects/typesystem/projects/state_machine/src/state_machine.rb
@@ -63,7 +63,7 @@ module Foobara
 
     def current_state
       if target_attribute
-        owner.send(target_attribute) || self.class.initial_state
+        owner.__send__(target_attribute) || self.class.initial_state
       else
         @current_state
       end
@@ -71,7 +71,7 @@ module Foobara
 
     def current_state=(state)
       if target_attribute
-        owner.send("#{target_attribute}=", state)
+        owner.__send__("#{target_attribute}=", state)
       else
         @current_state = state
       end

--- a/projects/typesystem/projects/value/src/processor/runner.rb
+++ b/projects/typesystem/projects/value/src/processor/runner.rb
@@ -11,7 +11,7 @@ module Foobara
                 if instance_variables.include?(instance_variable)
                   instance_variable_get(instance_variable)
                 else
-                  instance_variable_set(instance_variable, processor.send(method_name, value))
+                  instance_variable_set(instance_variable, processor.__send__(method_name, value))
                 end
               end
             end

--- a/projects/typesystem/spec/namespace/foobara_simulation_spec.rb
+++ b/projects/typesystem/spec/namespace/foobara_simulation_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Foobara::Namespace do
   after do
-    Object.send(:remove_const, :FoobaraSimulation)
+    Object.__send__(:remove_const, :FoobaraSimulation)
   end
 
   before do

--- a/projects/typesystem/spec/state_machine/callbacks_spec.rb
+++ b/projects/typesystem/spec/state_machine/callbacks_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Foobara::StateMachine::Callbacks do
                 record_call
               end
 
-      state_machine.send(callback_name, &block)
+      state_machine.__send__(callback_name, &block)
     end
 
     it "calls them all" do

--- a/projects/typesystem/spec/value/caster_spec.rb
+++ b/projects/typesystem/spec/value/caster_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Foobara::Value::Caster do
     end
 
     after do
-      described_class.send(:remove_const, :Always1000)
+      described_class.__send__(:remove_const, :Always1000)
     end
 
     it "creates caster instance with desired behavior" do

--- a/spec/domain/domain_spec.rb
+++ b/spec/domain/domain_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Foobara::Domain do
 
   describe ".create" do
     after do
-      Object.send(:remove_const, "SomeOrg")
+      Object.__send__(:remove_const, "SomeOrg")
     end
 
     it "creates a domain and its org" do
@@ -124,7 +124,7 @@ RSpec.describe Foobara::Domain do
 
   describe "Organization.create" do
     after do
-      Object.send(:remove_const, "A") if Object.const_defined?("A")
+      Object.__send__(:remove_const, "A") if Object.const_defined?("A")
     end
 
     context "when organization parent modules don't exist" do


### PR DESCRIPTION
Replaces reflective `send` calls with `__send__` throughout the codebase. This avoids conflicts with classes such as `Ractor` that define their own `send` method.

Tests: `bundle exec rake` (832 examples, 0 failures; 100% coverage)

Fixes #86