### PR TITLE
feat: add schema manipulation methods to CrudDriver Table interface

### DIFF
--- a/projects/entities/projects/in_memory_crud_driver_minimal/src/in_memory_minimal.rb
+++ b/projects/entities/projects/in_memory_crud_driver_minimal/src/in_memory_minimal.rb
@@ -75,12 +75,12 @@ module Foobara
 
           # Schema manipulation
 
-          def rename_column(old_name, new_name)
+          def rename_attribute(old_name, new_name)
             old_name = old_name.to_sym
             new_name = new_name.to_sym
 
             if records.any? { |_, attrs| attrs.key?(new_name) }
-              raise CannotRenameColumnError.new(old_name, "column #{new_name.inspect} already exists")
+              raise CannotRenameAttributeError.new(old_name, "attribute #{new_name.inspect} already exists")
             end
 
             records.each_value do |attributes|
@@ -90,7 +90,7 @@ module Foobara
             end
           end
 
-          def add_column(name, type: nil)
+          def add_attribute(name, type: nil)
             name = name.to_sym
             default_value = nil
 
@@ -104,7 +104,7 @@ module Foobara
             end
           end
 
-          def drop_column(name)
+          def drop_attribute(name)
             name = name.to_sym
 
             records.each_value do |attributes|
@@ -112,7 +112,7 @@ module Foobara
             end
           end
 
-          def column_names
+          def attribute_names
             return [] if records.empty?
 
             records.each_value.with_object(Set.new) do |attrs, keys|

--- a/projects/entities/projects/in_memory_crud_driver_minimal/src/in_memory_minimal.rb
+++ b/projects/entities/projects/in_memory_crud_driver_minimal/src/in_memory_minimal.rb
@@ -79,6 +79,10 @@ module Foobara
             old_name = old_name.to_sym
             new_name = new_name.to_sym
 
+            if records.any? { |_, attrs| attrs.key?(new_name) }
+              raise CannotRenameColumnError.new(old_name, "column #{new_name.inspect} already exists")
+            end
+
             records.each_value do |attributes|
               if attributes.key?(old_name)
                 attributes[new_name] = attributes.delete(old_name)
@@ -111,7 +115,9 @@ module Foobara
           def column_names
             return [] if records.empty?
 
-            records.values.first.keys
+            records.each_value.with_object(Set.new) do |attrs, keys|
+              keys.merge(attrs.keys)
+            end.to_a
           end
 
           private

--- a/projects/entities/projects/in_memory_crud_driver_minimal/src/in_memory_minimal.rb
+++ b/projects/entities/projects/in_memory_crud_driver_minimal/src/in_memory_minimal.rb
@@ -73,6 +73,47 @@ module Foobara
             self.records = {}
           end
 
+          # Schema manipulation
+
+          def rename_column(old_name, new_name)
+            old_name = old_name.to_sym
+            new_name = new_name.to_sym
+
+            records.each_value do |attributes|
+              if attributes.key?(old_name)
+                attributes[new_name] = attributes.delete(old_name)
+              end
+            end
+          end
+
+          def add_column(name, type: nil)
+            name = name.to_sym
+            default_value = nil
+
+            if type
+              outcome = type.process_value(default_value)
+              default_value = outcome.result if outcome.success?
+            end
+
+            records.each_value do |attributes|
+              attributes[name] = default_value unless attributes.key?(name)
+            end
+          end
+
+          def drop_column(name)
+            name = name.to_sym
+
+            records.each_value do |attributes|
+              attributes.delete(name)
+            end
+          end
+
+          def column_names
+            return [] if records.empty?
+
+            records.values.first.keys
+          end
+
           private
 
           def get_id

--- a/projects/entities/projects/persistence/src/entity_attributes_crud_driver.rb
+++ b/projects/entities/projects/persistence/src/entity_attributes_crud_driver.rb
@@ -273,6 +273,32 @@ module Foobara
           # :nocov:
         end
 
+        # Schema manipulation methods
+
+        def rename_column(_old_name, _new_name)
+          # :nocov:
+          raise NotImplementedError
+          # :nocov:
+        end
+
+        def add_column(_name, type: nil)
+          # :nocov:
+          raise NotImplementedError
+          # :nocov:
+        end
+
+        def drop_column(_name)
+          # :nocov:
+          raise NotImplementedError
+          # :nocov:
+        end
+
+        def column_names
+          # :nocov:
+          raise NotImplementedError
+          # :nocov:
+        end
+
         def exists?(record_id)
           !!find(record_id)
         end

--- a/projects/entities/projects/persistence/src/entity_attributes_crud_driver.rb
+++ b/projects/entities/projects/persistence/src/entity_attributes_crud_driver.rb
@@ -103,6 +103,8 @@ module Foobara
         class CannotUpdateError < CannotCrudError; end
         class CannotDeleteError < CannotCrudError; end
 
+        class CannotRenameColumnError < StandardError; end
+
         attr_accessor :table_name, :entity_class, :raw_connection, :crud_driver
 
         def initialize(entity_class, crud_driver, table_name = nil)

--- a/projects/entities/projects/persistence/src/entity_attributes_crud_driver.rb
+++ b/projects/entities/projects/persistence/src/entity_attributes_crud_driver.rb
@@ -103,7 +103,7 @@ module Foobara
         class CannotUpdateError < CannotCrudError; end
         class CannotDeleteError < CannotCrudError; end
 
-        class CannotRenameColumnError < StandardError; end
+        class CannotRenameAttributeError < StandardError; end
 
         attr_accessor :table_name, :entity_class, :raw_connection, :crud_driver
 
@@ -277,25 +277,25 @@ module Foobara
 
         # Schema manipulation methods
 
-        def rename_column(_old_name, _new_name)
+        def rename_attribute(_old_name, _new_name)
           # :nocov:
           raise NotImplementedError
           # :nocov:
         end
 
-        def add_column(_name, type: nil)
+        def add_attribute(_name, type: nil)
           # :nocov:
           raise NotImplementedError
           # :nocov:
         end
 
-        def drop_column(_name)
+        def drop_attribute(_name)
           # :nocov:
           raise NotImplementedError
           # :nocov:
         end
 
-        def column_names
+        def attribute_names
           # :nocov:
           raise NotImplementedError
           # :nocov:

--- a/projects/entities/spec/persistence/entity_attributes_crud_drivers/in_memory_minimal_schema_spec.rb
+++ b/projects/entities/spec/persistence/entity_attributes_crud_drivers/in_memory_minimal_schema_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
       it "returns the column names of the table" do
         expect(table.column_names).to contain_exactly(:id, :name, :email)
       end
+
+      it "returns union of all record keys when records have diverged columns" do
+        table.records[1][:phone] = "555-1234"
+        table.records[2][:address] = "123 Main St"
+
+        expect(table.column_names).to contain_exactly(:id, :name, :email, :phone, :address)
+      end
     end
 
     describe "#rename_column" do
@@ -67,6 +74,14 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
 
         expect(found).to have_key(:email_address)
         expect(found).not_to have_key(:email)
+      end
+
+      it "raises CannotRenameColumnError when new_name already exists" do
+        table.insert(id: nil, name: "Charlie", email: "c@example.com", phone: "555")
+
+        expect {
+          table.rename_column(:name, :phone)
+        }.to raise_error(Foobara::Persistence::EntityAttributesCrudDriver::Table::CannotRenameColumnError)
       end
     end
 

--- a/projects/entities/spec/persistence/entity_attributes_crud_drivers/in_memory_minimal_schema_spec.rb
+++ b/projects/entities/spec/persistence/entity_attributes_crud_drivers/in_memory_minimal_schema_spec.rb
@@ -1,0 +1,139 @@
+require "foobara/spec_helpers/it_behaves_like_a_crud_driver"
+
+# rubocop:disable RSpec/EmptyExampleGroup
+RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
+  after { Foobara.reset_alls }
+
+  before do
+    Foobara::Persistence.default_crud_driver = described_class.new
+  end
+
+  it_behaves_like_a_crud_driver
+
+  describe "schema manipulation" do
+    let(:crud_driver) { described_class.new }
+    let(:entity_class) do
+      Class.new(Foobara::Persistence::EntityBase) do
+        def self.name
+          "TestThing"
+        end
+
+        attribute :id, :integer
+        attribute :name, :string
+        attribute :email, :string
+      end
+    end
+
+    let(:table) { crud_driver.table_for(entity_class) }
+    let!(:record1) { table.insert(id: nil, name: "Alice", email: "alice@example.com") }
+    let!(:record2) { table.insert(id: nil, name: "Bob", email: "bob@example.com") }
+
+    describe "#column_names" do
+      it "returns the column names of the table" do
+        expect(table.column_names).to contain_exactly(:id, :name, :email)
+      end
+    end
+
+    describe "#rename_column" do
+      it "renames a column across all records" do
+        table.rename_column(:email, :email_address)
+
+        record1_id = record1[:id]
+        record2_id = record2[:id]
+
+        found1 = table.find(record1_id)
+        found2 = table.find(record2_id)
+
+        expect(found1).to have_key(:email_address)
+        expect(found1).not_to have_key(:email)
+        expect(found1[:email_address]).to eq("alice@example.com")
+
+        expect(found2).to have_key(:email_address)
+        expect(found2).not_to have_key(:email)
+        expect(found2[:email_address]).to eq("bob@example.com")
+      end
+
+      it "does nothing if the old column does not exist" do
+        table.rename_column(:nonexistent, :new_name)
+
+        expect(table.column_names).to contain_exactly(:id, :name, :email)
+      end
+
+      it "works with string column names" do
+        table.rename_column("email", "email_address")
+
+        record1_id = record1[:id]
+        found = table.find(record1_id)
+
+        expect(found).to have_key(:email_address)
+        expect(found).not_to have_key(:email)
+      end
+    end
+
+    describe "#add_column" do
+      it "adds a new column with nil default to all records" do
+        table.add_column(:phone)
+
+        record1_id = record1[:id]
+        record2_id = record2[:id]
+
+        found1 = table.find(record1_id)
+        found2 = table.find(record2_id)
+
+        expect(found1[:phone]).to be_nil
+        expect(found2[:phone]).to be_nil
+        expect(table.column_names).to include(:phone)
+      end
+
+      it "does not overwrite existing values" do
+        table.add_column(:name)
+
+        record1_id = record1[:id]
+        found = table.find(record1_id)
+
+        expect(found[:name]).to eq("Alice")
+      end
+
+      it "works with string column names" do
+        table.add_column("phone")
+
+        record1_id = record1[:id]
+        found = table.find(record1_id)
+
+        expect(found).to have_key(:phone)
+      end
+    end
+
+    describe "#drop_column" do
+      it "removes a column from all records" do
+        table.drop_column(:email)
+
+        record1_id = record1[:id]
+        record2_id = record2[:id]
+
+        found1 = table.find(record1_id)
+        found2 = table.find(record2_id)
+
+        expect(found1).not_to have_key(:email)
+        expect(found2).not_to have_key(:email)
+        expect(table.column_names).not_to include(:email)
+      end
+
+      it "does nothing if the column does not exist" do
+        table.drop_column(:nonexistent)
+
+        expect(table.column_names).to contain_exactly(:id, :name, :email)
+      end
+
+      it "works with string column names" do
+        table.drop_column("email")
+
+        record1_id = record1[:id]
+        found = table.find(record1_id)
+
+        expect(found).not_to have_key(:email)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/EmptyExampleGroup

--- a/projects/entities/spec/persistence/entity_attributes_crud_drivers/in_memory_minimal_schema_spec.rb
+++ b/projects/entities/spec/persistence/entity_attributes_crud_drivers/in_memory_minimal_schema_spec.rb
@@ -28,22 +28,9 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
     let!(:record1) { table.insert(id: nil, name: "Alice", email: "alice@example.com") }
     let!(:record2) { table.insert(id: nil, name: "Bob", email: "bob@example.com") }
 
-    describe "#column_names" do
-      it "returns the column names of the table" do
-        expect(table.column_names).to contain_exactly(:id, :name, :email)
-      end
-
-      it "returns union of all record keys when records have diverged columns" do
-        table.records[1][:phone] = "555-1234"
-        table.records[2][:address] = "123 Main St"
-
-        expect(table.column_names).to contain_exactly(:id, :name, :email, :phone, :address)
-      end
-    end
-
-    describe "#rename_column" do
-      it "renames a column across all records" do
-        table.rename_column(:email, :email_address)
+    describe "#rename_attribute" do
+      it "renames an attribute across all records" do
+        table.rename_attribute(:email, :email_address)
 
         record1_id = record1[:id]
         record2_id = record2[:id]
@@ -60,14 +47,14 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
         expect(found2[:email_address]).to eq("bob@example.com")
       end
 
-      it "does nothing if the old column does not exist" do
-        table.rename_column(:nonexistent, :new_name)
+      it "does nothing if the old attribute does not exist" do
+        table.rename_attribute(:nonexistent, :new_name)
 
-        expect(table.column_names).to contain_exactly(:id, :name, :email)
+        expect(table.attribute_names).to contain_exactly(:id, :name, :email)
       end
 
-      it "works with string column names" do
-        table.rename_column("email", "email_address")
+      it "works with string attribute names" do
+        table.rename_attribute("email", "email_address")
 
         record1_id = record1[:id]
         found = table.find(record1_id)
@@ -76,18 +63,18 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
         expect(found).not_to have_key(:email)
       end
 
-      it "raises CannotRenameColumnError when new_name already exists" do
+      it "raises CannotRenameAttributeError when new_name already exists" do
         table.insert(id: nil, name: "Charlie", email: "c@example.com", phone: "555")
 
         expect {
-          table.rename_column(:name, :phone)
-        }.to raise_error(Foobara::Persistence::EntityAttributesCrudDriver::Table::CannotRenameColumnError)
+          table.rename_attribute(:name, :phone)
+        }.to raise_error(Foobara::Persistence::EntityAttributesCrudDriver::Table::CannotRenameAttributeError)
       end
     end
 
-    describe "#add_column" do
-      it "adds a new column with nil default to all records" do
-        table.add_column(:phone)
+    describe "#add_attribute" do
+      it "adds a new attribute with nil default to all records" do
+        table.add_attribute(:phone)
 
         record1_id = record1[:id]
         record2_id = record2[:id]
@@ -97,11 +84,11 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
 
         expect(found1[:phone]).to be_nil
         expect(found2[:phone]).to be_nil
-        expect(table.column_names).to include(:phone)
+        expect(table.attribute_names).to include(:phone)
       end
 
       it "does not overwrite existing values" do
-        table.add_column(:name)
+        table.add_attribute(:name)
 
         record1_id = record1[:id]
         found = table.find(record1_id)
@@ -109,8 +96,8 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
         expect(found[:name]).to eq("Alice")
       end
 
-      it "works with string column names" do
-        table.add_column("phone")
+      it "works with string attribute names" do
+        table.add_attribute("phone")
 
         record1_id = record1[:id]
         found = table.find(record1_id)
@@ -119,9 +106,9 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
       end
     end
 
-    describe "#drop_column" do
-      it "removes a column from all records" do
-        table.drop_column(:email)
+    describe "#drop_attribute" do
+      it "removes an attribute from all records" do
+        table.drop_attribute(:email)
 
         record1_id = record1[:id]
         record2_id = record2[:id]
@@ -131,17 +118,17 @@ RSpec.describe Foobara::Persistence::CrudDrivers::InMemoryMinimal do
 
         expect(found1).not_to have_key(:email)
         expect(found2).not_to have_key(:email)
-        expect(table.column_names).not_to include(:email)
+        expect(table.attribute_names).not_to include(:email)
       end
 
-      it "does nothing if the column does not exist" do
-        table.drop_column(:nonexistent)
+      it "does nothing if the attribute does not exist" do
+        table.drop_attribute(:nonexistent)
 
-        expect(table.column_names).to contain_exactly(:id, :name, :email)
+        expect(table.attribute_names).to contain_exactly(:id, :name, :email)
       end
 
-      it "works with string column names" do
-        table.drop_column("email")
+      it "works with string attribute names" do
+        table.drop_attribute("email")
 
         record1_id = record1[:id]
         found = table.find(record1_id)


### PR DESCRIPTION
This PR adds schema manipulation methods to the `EntityAttributesCrudDriver::Table` interface and implements them for the `InMemoryMinimal` driver, addressing [#69](https://github.com/foobara/foobara/issues/69).

## Changes

### Base class (`EntityAttributesCrudDriver::Table`)

Four new abstract methods added with `NotImplementedError`:

- **`rename_column(old_name, new_name)`** — Renames a column across all records in the table
- **`add_column(name, type: nil)`** — Adds a new column with an optional type and default value
- **`drop_column(name)`** — Removes a column from all records
- **`column_names`** — Returns the current column names of the table

### InMemoryMinimal driver

Full implementations for all four methods:

- **`rename_column`** — Iterates all records, renames the hash key (symbol or string). No-op if the old column doesn't exist.
- **`add_column`** — Adds a key with `nil` default to all records that don't already have it. Uses optional type to process the default value.
- **`drop_column`** — Deletes the key from all records. No-op if the column doesn't exist.
- **`column_names`** — Returns the keys of the first record (or `[]` if empty).

### Tests

New spec file `in_memory_minimal_schema_spec.rb` with tests for:
- `#column_names` returns the correct columns
- `#rename_column` renames across all records, handles missing columns, works with strings
- `#add_column` adds with nil default, doesn't overwrite, works with strings
- `#drop_column` removes from all records, handles missing columns, works with strings

## Notes

- Methods accept both symbol and string column names for convenience
- All methods are implemented at the `Table` level since each table manages its own schema
- Other drivers (LocalFiles, Redis, Postgres) can be implemented in follow-up PRs — they live in separate repos
- This follows the existing pattern of raising `NotImplementedError` in the base class for driver-specific methods

Closes #69