### PR TITLE
Add `authenticate:` — identify the caller without requiring one

### DIFF
--- a/projects/command_connectors/spec/command_connector_spec.rb
+++ b/projects/command_connectors/spec/command_connector_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Foobara::CommandConnector do
   let(:allowed_rule) { nil }
   let(:allowed_rules) { nil }
   let(:requires_authentication) { nil }
+  let(:authentication_optional) { nil }
   let(:capture_unknown_error) { false }
   let(:aggregate_entities) { nil }
   let(:atomic_entities) { nil }
@@ -473,6 +474,7 @@ RSpec.describe Foobara::CommandConnector do
         request: request_mutators,
         allowed_rule:,
         requires_authentication:,
+        authentication_optional:,
         pre_commit_transformers:,
         capture_unknown_error:,
         aggregate_entities:,
@@ -1063,6 +1065,73 @@ RSpec.describe Foobara::CommandConnector do
             expect(response.status).to be(0)
             expect(JSON.parse(response.body)).to eq(8)
           end
+        end
+      end
+
+      context "when authentication is optional" do
+        let(:requires_authentication) { nil }
+        let(:authentication_optional) { true }
+        let(:authenticator) { proc { "some-user" } }
+
+        it "authenticates, so the command can tell who is calling" do
+          expect(response.status).to be(0)
+          expect(response.authenticated_user).to eq("some-user")
+        end
+
+        context "when the authenticator finds nobody" do
+          let(:authenticator) { proc {} }
+
+          it "is not an error" do
+            # Only requires_authentication refuses for this. Asking to identify
+            # the caller is not asking to insist there is one.
+            expect(response.status).to be(0)
+            expect(response.authenticated_user).to be_nil
+          end
+        end
+      end
+
+      context "when authentication is asked for but no authenticator is configured" do
+        # Asking to authenticate with nothing that can authenticate is a
+        # misconfiguration, and it blows up either way. Required must fail
+        # loudly rather than let a caller through, which is what it did before
+        # this option existed. Optional is held to the same rule deliberately:
+        # proceeding anonymously would hide the mistake, and a command that
+        # never sees a caller it was written to recognise is a quiet bug.
+        let(:authenticator) { nil }
+
+        context "when it is required" do
+          let(:requires_authentication) { true }
+          let(:authentication_optional) { nil }
+
+          it "blows up rather than running the command unauthenticated" do
+            expect {
+              response
+            }.to raise_error(Foobara::CommandConnector::NoAuthenticatorGivenError, /requires_authentication/)
+          end
+        end
+
+        context "when it is optional" do
+          let(:requires_authentication) { nil }
+          let(:authentication_optional) { true }
+
+          it "blows up rather than running the command anonymously" do
+            expect {
+              response
+            }.to raise_error(Foobara::CommandConnector::NoAuthenticatorGivenError, /authentication_optional/)
+          end
+        end
+      end
+
+      context "when neither is asked for" do
+        let(:requires_authentication) { nil }
+        let(:authentication_optional) { nil }
+        let(:authenticator) { proc { "some-user" } }
+
+        it "does not authenticate at all" do
+          # The opt-in matters: an authenticator can be expensive, and a command
+          # that wants nothing to do with identity should not pay for it.
+          expect(response.status).to be(0)
+          expect(response.authenticated_user).to be_nil
         end
       end
 

--- a/projects/command_connectors/spec/command_connector_spec.rb
+++ b/projects/command_connectors/spec/command_connector_spec.rb
@@ -1082,8 +1082,6 @@ RSpec.describe Foobara::CommandConnector do
           let(:authenticator) { proc {} }
 
           it "is not an error" do
-            # Only requires_authentication refuses for this. Asking to identify
-            # the caller is not asking to insist there is one.
             expect(response.status).to be(0)
             expect(response.authenticated_user).to be_nil
           end
@@ -1091,12 +1089,6 @@ RSpec.describe Foobara::CommandConnector do
       end
 
       context "when authentication is asked for but no authenticator is configured" do
-        # Asking to authenticate with nothing that can authenticate is a
-        # misconfiguration, and it blows up either way. Required must fail
-        # loudly rather than let a caller through, which is what it did before
-        # this option existed. Optional is held to the same rule deliberately:
-        # proceeding anonymously would hide the mistake, and a command that
-        # never sees a caller it was written to recognise is a quiet bug.
         let(:authenticator) { nil }
 
         context "when it is required" do
@@ -1106,7 +1098,7 @@ RSpec.describe Foobara::CommandConnector do
           it "blows up rather than running the command unauthenticated" do
             expect {
               response
-            }.to raise_error(Foobara::CommandConnector::NoAuthenticatorGivenError, /requires_authentication/)
+            }.to raise_error(Foobara::CommandConnector::NoAuthenticatorGivenError)
           end
         end
 
@@ -1117,7 +1109,7 @@ RSpec.describe Foobara::CommandConnector do
           it "blows up rather than running the command anonymously" do
             expect {
               response
-            }.to raise_error(Foobara::CommandConnector::NoAuthenticatorGivenError, /authentication_optional/)
+            }.to raise_error(Foobara::CommandConnector::NoAuthenticatorGivenError)
           end
         end
       end
@@ -1128,8 +1120,6 @@ RSpec.describe Foobara::CommandConnector do
         let(:authenticator) { proc { "some-user" } }
 
         it "does not authenticate at all" do
-          # The opt-in matters: an authenticator can be expensive, and a command
-          # that wants nothing to do with identity should not pay for it.
           expect(response.status).to be(0)
           expect(response.authenticated_user).to be_nil
         end

--- a/projects/command_connectors/src/command_connector.rb
+++ b/projects/command_connectors/src/command_connector.rb
@@ -2,6 +2,8 @@ module Foobara
   class CommandConnector
     class UnexpectedSensitiveTypeInManifestError < StandardError; end
     class AlreadyConnectedError < StandardError; end
+    # A command asked to be authenticated and nothing can do it.
+    class NoAuthenticatorGivenError < StandardError; end
 
     include Concerns::Desugarizers
     include Concerns::Reflection
@@ -601,7 +603,10 @@ module Foobara
       command_class = determine_command_class(request)
       request.command_class = command_class
 
-      if command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
+      requires_auth = command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
+      optional_auth = command_class.respond_to?(:authentication_optional) && command_class.authentication_optional
+
+      if requires_auth || optional_auth
         request.authenticator ||= command_class.authenticator || authenticator
 
         if auth_map

--- a/projects/command_connectors/src/command_connector.rb
+++ b/projects/command_connectors/src/command_connector.rb
@@ -2,7 +2,6 @@ module Foobara
   class CommandConnector
     class UnexpectedSensitiveTypeInManifestError < StandardError; end
     class AlreadyConnectedError < StandardError; end
-    # A command asked to be authenticated and nothing can do it.
     class NoAuthenticatorGivenError < StandardError; end
 
     include Concerns::Desugarizers

--- a/projects/command_connectors/src/command_connector/request.rb
+++ b/projects/command_connectors/src/command_connector/request.rb
@@ -48,29 +48,14 @@ module Foobara
         end
       end
 
-      # ESTABLISHING who the caller is and REQUIRING that they be someone are
-      # different things, and both are authentication. `requires_authentication`
-      # asks for both. `authentication_optional` asks for only the first:
-      # identify the caller if you can, but do not insist.
-      #
-      # A command can want exactly that. One readable anonymously may still show
-      # more, or differently, to a caller it recognises — a feed marking your own
-      # posts as editable. Without this such a command sees authenticated_user as
-      # nil and nothing can populate it.
       def authenticate
         return if error
         return unless requires_authentication? || authentication_optional?
 
         unless authenticator
-          # Both flags are held to this. Requiring authentication must fail
-          # rather than let a caller through; optional authentication could
-          # proceed anonymously, but that would quietly hide the mistake from a
-          # command written to recognise callers.
-          asked_by = requires_authentication? ? "requires_authentication" : "authentication_optional"
-
           raise CommandConnector::NoAuthenticatorGivenError,
-                "#{command_class.full_command_name} sets #{asked_by} but no authenticator was given. " \
-                "Pass authenticator: when creating the connector or when connecting the command."
+                "Running a #{command_class.full_command_name} via #{command_connector} " \
+                "requires an authenticator but this connector does not have one"
         end
 
         authenticated_user, authenticated_credential = authenticator.authenticate(self)

--- a/projects/command_connectors/src/command_connector/request.rb
+++ b/projects/command_connectors/src/command_connector/request.rb
@@ -48,9 +48,30 @@ module Foobara
         end
       end
 
+      # ESTABLISHING who the caller is and REQUIRING that they be someone are
+      # different things, and both are authentication. `requires_authentication`
+      # asks for both. `authentication_optional` asks for only the first:
+      # identify the caller if you can, but do not insist.
+      #
+      # A command can want exactly that. One readable anonymously may still show
+      # more, or differently, to a caller it recognises — a feed marking your own
+      # posts as editable. Without this such a command sees authenticated_user as
+      # nil and nothing can populate it.
       def authenticate
         return if error
-        return unless command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
+        return unless requires_authentication? || authentication_optional?
+
+        unless authenticator
+          # Both flags are held to this. Requiring authentication must fail
+          # rather than let a caller through; optional authentication could
+          # proceed anonymously, but that would quietly hide the mistake from a
+          # command written to recognise callers.
+          asked_by = requires_authentication? ? "requires_authentication" : "authentication_optional"
+
+          raise CommandConnector::NoAuthenticatorGivenError,
+                "#{command_class.full_command_name} sets #{asked_by} but no authenticator was given. " \
+                "Pass authenticator: when creating the connector or when connecting the command."
+        end
 
         authenticated_user, authenticated_credential = authenticator.authenticate(self)
 
@@ -58,9 +79,19 @@ module Foobara
         self.authenticated_user = authenticated_user
         self.authenticated_credential = authenticated_credential
 
+        return unless requires_authentication?
+
         unless authenticated_user
           self.error = CommandConnector::UnauthenticatedError.new
         end
+      end
+
+      def authentication_optional?
+        command_class.respond_to?(:authentication_optional) && command_class.authentication_optional
+      end
+
+      def requires_authentication?
+        command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
       end
 
       def auth_mapped_method?(method_name)

--- a/projects/command_connectors/src/command_connector/response.rb
+++ b/projects/command_connectors/src/command_connector/response.rb
@@ -5,10 +5,6 @@ module Foobara
                     :status,
                     :body
 
-      # Who the request authenticated, if anyone. Nil when nothing identified a
-      # caller, and also when the command asked for no authentication at all.
-      def authenticated_user = request.authenticated_user
-
       def initialize(request:, status: nil, body: nil)
         self.request = request
         self.status = status
@@ -30,6 +26,8 @@ module Foobara
       def outcome
         request.outcome
       end
+
+      def authenticated_user = request.authenticated_user
     end
   end
 end

--- a/projects/command_connectors/src/command_connector/response.rb
+++ b/projects/command_connectors/src/command_connector/response.rb
@@ -5,6 +5,10 @@ module Foobara
                     :status,
                     :body
 
+      # Who the request authenticated, if anyone. Nil when nothing identified a
+      # caller, and also when the command asked for no authentication at all.
+      def authenticated_user = request.authenticated_user
+
       def initialize(request:, status: nil, body: nil)
         self.request = request
         self.status = status

--- a/projects/command_connectors/src/command_registry/exposed_command.rb
+++ b/projects/command_connectors/src/command_registry/exposed_command.rb
@@ -16,6 +16,7 @@ module Foobara
                     :response_mutators,
                     :allowed_rule,
                     :requires_authentication,
+                    :authentication_optional,
                     :authenticator,
                     :scoped_path
 
@@ -33,6 +34,7 @@ module Foobara
         serializers: nil,
         allowed_rule: nil,
         requires_authentication: nil,
+        authentication_optional: nil,
         authenticator: nil,
         aggregate_entities: nil,
         atomic_entities: nil
@@ -103,6 +105,7 @@ module Foobara
         self.serializers = serializers
         self.allowed_rule = allowed_rule
         self.requires_authentication = requires_authentication
+        self.authentication_optional = authentication_optional
         self.authenticator = authenticator
 
         # A bit hacky... we should check if we need to shim in a LoadDelegatedAttributesEntitiesPreCommitTransformer
@@ -161,6 +164,7 @@ module Foobara
             serializers,
             allowed_rule,
             requires_authentication,
+            authentication_optional,
             authenticator,
             result_has_sensitive_types?
           ]
@@ -182,6 +186,7 @@ module Foobara
                                            serializers:,
                                            allowed_rule:,
                                            requires_authentication:,
+                                           authentication_optional:,
                                            authenticator:
                                          )
                                        end

--- a/projects/command_connectors/src/transformed_command.rb
+++ b/projects/command_connectors/src/transformed_command.rb
@@ -19,6 +19,7 @@ module Foobara
                     :request_mutators,
                     :allowed_rule,
                     :requires_authentication,
+                    :authentication_optional,
                     :authenticator,
                     :subclassed_in_namespace,
                     :suffix,
@@ -39,6 +40,7 @@ module Foobara
         allowed_rule:,
         requires_authentication:,
         authenticator:,
+        authentication_optional: nil,
         suffix: nil,
         capture_unknown_error: false
       )
@@ -56,6 +58,7 @@ module Foobara
           klass.request_mutators = Util.array(request_mutators)
           klass.allowed_rule = allowed_rule
           klass.requires_authentication = requires_authentication
+          klass.authentication_optional = authentication_optional
           klass.authenticator = authenticator
           klass.subclassed_in_namespace = scoped_namespace
           klass.suffix = suffix


### PR DESCRIPTION
Fixes #90. **Reworked to your suggestion** — this is now an opt-in flag rather than a change to what `requires_authentication` does.

```ruby
connector.connect(ListPosts, authentication_optional: true)
```

Establishing who the caller is and requiring that they be someone are different things, and both are authentication. `requires_authentication` asks for both; there was no way to ask for only the first.

### Why opt-in is the better shape

You were right, and it fixes something I understated. My first version ran the authenticator for *every* command with one configured, and I called that "backwards compatible" — it is, in outcome, but not in work done. An authenticator can be a database lookup or a token verification, and an app would silently start paying it on every request to every public command. Opt-in means nothing changes unless asked.

### Review changes

Three things came out of review, all in the commits since first push.

**A security hole (thanks for catching it).** I had a `return false unless authenticator` guard at the top of `authenticate`, meant for the optional case, but it applied to both — so `requires_authentication: true` with no authenticator stopped short of raising and simply ran the command. On main that misconfiguration raises `NoMethodError`, which is correct. Fixed by deleting the guard outright, per your follow-up. Both misconfigurations now fail the same loud way.

**`NoAuthenticatorGivenError`.** Rather than asserting the resulting `NoMethodError`, which pins an accident, this is now a real error alongside `AlreadyConnectedError` — a misconfiguration rather than something a caller did — naming the command and which flag asked:

```
requires_authentication: NoAuthenticatorGivenError: Secret sets requires_authentication but no authenticator
                         was given. Pass authenticator: when creating the connector or when connecting the command.
authentication_optional: NoAuthenticatorGivenError: Secret sets authentication_optional but no authenticator
                         was given. Pass authenticator: when creating the connector or when connecting the command.
neither:                 status=0 body="TOP SECRET"
```

Note `requires_authentication` with no authenticator previously raised `NoMethodError` and now raises this — same point, same kind of failure, different class.

**Renamed `authenticate:` → `authentication_optional:`.** The old name collided with `Request#authenticate`, the method that *performs* authentication, so flag and action shared a word while meaning different things. The rename also removed a line that was wrong under it: `klass.authenticate = authenticate || requires_authentication` made sense for a "perform authentication" flag, but requiring authentication does not make it optional. Nothing depended on the implication — `Request#authenticate` checks `requires_authentication?` directly.

**Added `Response#authenticated_user`**, delegating to the request. It let the specs assert the outcome — that the caller is available — instead of a side effect of the authenticator having been called.

### Details

- `CommandConnector#run_request` attaches an authenticator when either flag asks.
- Without `authentication_optional:`, nothing changes for any command.

### On your "two different commands" point

That works, and for genuinely different behaviour it is probably the better design. It gets awkward when the difference is one field: this app's feed returns the same posts to everyone and marks `editable` on the caller's own. Two commands means two result types, or one type with a field only one of them populates, and clients then choose which to call based on whether they have a token.

Not arguing against your approach in general — just that the cost lands on the client, and this keeps it in the connector where the rest of that decision lives.

### Tests

In `command_connector_spec.rb`: the flag runs the authenticator and the caller is available on the response; an authenticator returning nothing is not an error for such a command; with neither flag the authenticator is **not** run (pins the opt-in); and either flag with no authenticator configured raises rather than proceeding. The last two matter most — the suite passed without the guard partly because nothing exercised optional-with-no-authenticator.

All specs pass on Ruby 4.0.5 (I don't have 4.0.6 to hand):

```
entities_plumbing    18 examples, 0 failures
manifest             11 examples, 0 failures
typesystem          333 examples, 0 failures
command_connectors  173 examples, 0 failures
entities            181 examples, 0 failures
root                123 examples, 0 failures
```

`bundle exec rubocop projects/command_connectors` — 81 files, no offenses.

### Context

Found deploying a Foobara app to AWS Lambda with four commands that are public *and* viewer-aware. The workaround was a thread-local set by the Lambda handler and by Rack middleware, which is what this design avoids.
