### PR TITLE
Give Request a requires_authentication? and ask it from run_request

### DIFF
--- a/projects/command_connectors/spec/request_spec.rb
+++ b/projects/command_connectors/spec/request_spec.rb
@@ -3,6 +3,26 @@ RSpec.describe Foobara::CommandConnector::Request do
     described_class.new
   end
 
+  describe "#requires_authentication?" do
+    it "is false when no command class has been determined yet" do
+      # run_request asks this before it checks whether a command was found at
+      # all, so nil has to be an answer rather than an exception.
+      expect(request.requires_authentication?).to be false
+    end
+
+    it "is false for a command class that says nothing about authentication" do
+      request.command_class = Class.new
+
+      expect(request.requires_authentication?).to be false
+    end
+
+    it "is true when the command class requires it" do
+      request.command_class = Class.new { def self.requires_authentication = true }
+
+      expect(request.requires_authentication?).to be true
+    end
+  end
+
   describe "#serializer" do
     before do
       request.serializers = serializers

--- a/projects/command_connectors/src/command_connector.rb
+++ b/projects/command_connectors/src/command_connector.rb
@@ -601,7 +601,7 @@ module Foobara
       command_class = determine_command_class(request)
       request.command_class = command_class
 
-      if command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
+      if request.requires_authentication?
         request.authenticator ||= command_class.authenticator || authenticator
 
         if auth_map

--- a/projects/command_connectors/src/command_connector/request.rb
+++ b/projects/command_connectors/src/command_connector/request.rb
@@ -48,9 +48,16 @@ module Foobara
         end
       end
 
+      # respond_to? rather than `command_class < TransformedCommand`: it is nil
+      # until determine_command_class has run and stays nil when the request
+      # already failed, and Request does not require a TransformedCommand.
+      def requires_authentication?
+        command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
+      end
+
       def authenticate
         return if error
-        return unless command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
+        return unless requires_authentication?
 
         authenticated_user, authenticated_credential = authenticator.authenticate(self)
 


### PR DESCRIPTION
From your review comment on #91:

> Seems like it would be nice to have some helper methods on TransformedCommand for this at this point. And technically I think it would have been better if I had done something like `if command_class < TransformedCommand` around this instead of the respond_to? checks.

This does the first half. The second half turns out not to be equivalent, and the evidence is below — I would rather show you that than change it quietly.

### The helper

`run_request` and `Request#authenticate` each spelled out the same pair:

```ruby
command_class.respond_to?(:requires_authentication) && command_class.requires_authentication
```

They have to agree: `run_request` decides from it whether to give the request an authenticator, and `authenticate` then uses that authenticator. Now they ask one method, `Request#requires_authentication?`.

### Why not `command_class < TransformedCommand`

Two reasons, one mundane and one that surprised me.

**`command_class` can be nil.** It is nil until `determine_command_class` has run, and stays nil when the request already failed — `run_request` asks about authentication *before* `return build_response(request) unless command_class`. So `respond_to?` is doing double duty, and the strict form needs an `is_a?(Class)` guard just to not raise.

**`Request` does not require a `TransformedCommand`.** Your auth-mapped example in `request_spec.rb` drives it with a plain `Foobara::Command`:

```ruby
let(:command_class) do
  stub_class("SomeCommand", Foobara::Command) do
    def self.requires_authentication = true
  end
end
```

I tried the strict version first, and that spec goes red: `authenticate` returns early, nothing populates `authenticated_user`, and the auth mappers never run.

```
1) Foobara::CommandConnector::Request with an auth-mapped method can access the auth-mapped method
   expected: :bar
        got: nil
```

Worth saying that the *production* path would be fine — `transformed_command_from_name` and `transform_command_class` both return `.transformed_command_class`, so within this repo `command_class` is always a `TransformedCommand` subclass or nil. It is only the duck-typed path that changes, and I did not want to decide on your behalf whether that spec represents something supported or is just a convenient stub. If it is the latter, the strict version is a small change on top of this one and I am happy to add it here.

That is also why there is no new predicate on `TransformedCommand` itself: while `Request` accepts duck-typed classes, a `TransformedCommand#requires_authentication?` would never be the thing called, so it would be dead on arrival.

### Tests

Three examples for the new method — nil command class, a class that says nothing, and one that requires it. The first pins the nil case, which is the one that would break under the strict form.

All specs pass on Ruby 4.0.5 (I don't have 4.0.6 to hand):

```
entities_plumbing    18 examples, 0 failures
manifest             11 examples, 0 failures
typesystem          333 examples, 0 failures
command_connectors  171 examples, 0 failures
entities            181 examples, 0 failures
root                123 examples, 0 failures
```

`bundle exec rubocop projects/command_connectors` — 81 files, no offenses.

### Note on #91

This touches `run_request` and `Request#authenticate`, which #91 also touches, so whichever lands second will need a small rebase. Happy to do it in either order.