### PR TITLE
update RuboCop TargetRubyVersion to 4.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 4.0
   NewCops: enable
 
 inherit_gem:


### PR DESCRIPTION
Updated the version from 3.2 to 4.0 to better align with the current Ruby version (4.0.6).